### PR TITLE
feat: 로그아웃 핸들러 기능 구현

### DIFF
--- a/src/acceptance-test/java/woowacrew/oauth/controller/LoginControllerTest.java
+++ b/src/acceptance-test/java/woowacrew/oauth/controller/LoginControllerTest.java
@@ -79,4 +79,16 @@ class LoginControllerTest extends CommonTestController {
                     assertThat(body.contains("닉네임")).isTrue();
                 });
     }
+
+    @Test
+    void 로그아웃시_200을_리턴한다() {
+        String cookie = loginWithPrecourse();
+
+        webTestClient.get()
+                .uri("/logout")
+                .header("Cookie", cookie)
+                .exchange()
+                .expectStatus()
+                .isOk();
+    }
 }

--- a/src/main/java/woowacrew/security/AbstractSecurityConfig.java
+++ b/src/main/java/woowacrew/security/AbstractSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import woowacrew.security.filter.AuthorityUpdateFilter;
 import woowacrew.security.filter.SocialLoginFilter;
 import woowacrew.security.handler.AccessDenyHandler;
+import woowacrew.security.handler.CustomLogoutSuccessHandler;
 import woowacrew.security.requestmatcher.AuthorityUpdateRequestMatcher;
 import woowacrew.user.domain.UserRole;
 
@@ -65,7 +66,7 @@ public abstract class AbstractSecurityConfig extends WebSecurityConfigurerAdapte
                 .exceptionHandling().accessDeniedHandler(new AccessDenyHandler())
                 .and()
                 .logout()
-                .logoutSuccessUrl("/");
+                .logoutSuccessHandler(new CustomLogoutSuccessHandler());
         http
                 .addFilterBefore(socialLoginFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(authorityUpdateFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/woowacrew/security/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/woowacrew/security/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,17 @@
+package woowacrew.security.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        response.setStatus(HttpStatus.OK.value());
+    }
+}


### PR DESCRIPTION
resolve #225 

- [x] 로그아웃을 api로 처리하기 위해 별도의 핸들러를 구현
 -> 기존의 방식은 Spring Seucurity에서 지원하는 302 리다이렉션을 사용