### PR TITLE
feat: 왼쪽 메뉴바 토글 버튼 추가 (모바일)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
     <v-app-bar color="#212121" dark app style="left: 0; z-index: 5">
+      <v-app-bar-nav-icon class="side-nav-toggle-btn" @click="toggle()" />
       <a style="padding-left: 8px; text-decoration: none" href="/">
         <span class="font-weight-black white--text">WOOWA CREW</span>
       </a>
@@ -10,7 +11,15 @@
       <LoginHeader />
     </v-app-bar>
 
-    <SideNav />
+    <v-navigation-drawer
+      v-model="drawer"
+      width="280px"
+      style="z-index: 4"
+      app
+      disable-resize-watcher
+    >
+      <SideNav />
+    </v-navigation-drawer>
 
     <v-content>
       <router-view />
@@ -24,14 +33,24 @@ import SideNav from "./components/side/SideNav";
 
 export default {
   name: "App",
-
+  data: () => ({
+    drawer: true
+  }),
   components: {
     LoginHeader,
     SideNav
   },
-
-  data: () => ({
-    //
-  })
+  methods: {
+    toggle() {
+      this.drawer = !this.drawer;
+    }
+  }
 };
 </script>
+<style>
+@media all and (min-width: 1025px) {
+  .side-nav-toggle-btn {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/components/side/SideNav.vue
+++ b/frontend/src/components/side/SideNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-navigation-drawer width="280px" style="z-index: 4" permanent app>
+  <div>
     <v-list-item style="height: 63px; padding-left: 24px">
       <v-list-item-content>
         <v-list-item-title class="font-weight-black">
@@ -12,7 +12,7 @@
     <AdminMenu v-if="isAdmin" />
     <ArticleMenu />
     <ServiceMenu />
-  </v-navigation-drawer>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
resolved #315 

![image](https://user-images.githubusercontent.com/41109150/74042634-3efbb380-4a0b-11ea-8fbc-69c3ef5f0f23.png)

- PC or 아이패드 프로 가로 사이즈에서 토글 버튼 없이 왼쪽 메뉴바 항상 노출
- 모바일 or 태블릿에서 토글 버튼 노출 o