### PR TITLE
feat: 메인 페이지에 최근 슬랙 메세지 노출

### DIFF
--- a/frontend/src/components/home/Notice.vue
+++ b/frontend/src/components/home/Notice.vue
@@ -2,7 +2,9 @@
   <v-card flat>
     <v-card-text v-if="isLogin && existMessage">
       <div v-if="downloadLinkFromSlack" style="padding: 16px">
-        <a :href="downloadLinkFromSlack" class="title">#{{ channel }} - {{ author }}</a>
+        <a :href="downloadLinkFromSlack" class="title">
+          #{{ channel }} - {{ author }}
+        </a>
       </div>
       <div v-else style="padding: 16px; color: gray">
         <strong class="title">#{{ channel }} - {{ author }}</strong>

--- a/frontend/src/components/home/Notice.vue
+++ b/frontend/src/components/home/Notice.vue
@@ -1,18 +1,73 @@
 <template>
   <v-card flat>
-    <v-card-text>
-      <div style="padding: 16px">
-        <strong class="title">공지사항</strong>
+    <v-card-text v-if="isLogin && existMessage">
+      <div v-if="downloadLinkFromSlack" style="padding: 16px">
+        <a :href="downloadLinkFromSlack" class="title">#{{ channel }} - {{ author }}</a>
+      </div>
+      <div v-else style="padding: 16px; color: gray">
+        <strong class="title">#{{ channel }} - {{ author }}</strong>
+      </div>
+      <div
+        v-if="downloadLink"
+        style="padding: 12px 12px 16px 16px; background-color: #f5f5f5"
+      >
+        <div style="margin-bottom: 10px">첨부 파일</div>
+        <a :href="downloadLink">즉시 다운로드 받을 수 있는 링크 입니다.</a>
       </div>
       <div style="padding: 12px 12px 16px 16px">
-        내용
+        {{ content }}
       </div>
+    </v-card-text>
+    <v-card-text v-else-if="!isLogin">
+      로그인이 필요합니다.
+    </v-card-text>
+    <v-card-text v-else-if="!existMessage">
+      최근 슬랙 메세지가 존재하지 않습니다.
     </v-card-text>
   </v-card>
 </template>
 
 <script>
+import axios from "axios";
+
 export default {
-  name: "Notice"
+  name: "Notice",
+  data() {
+    return {
+      id: null,
+      channel: null,
+      author: null,
+      content: null,
+      downloadLink: null,
+      downloadLinkFromSlack: null,
+      createdDate: null
+    };
+  },
+  created() {
+    const requestUrl = this.$store.state.requestUrl + "/api/slack/notice";
+
+    axios
+      .get(requestUrl, {
+        withCredentials: true
+      })
+      .then(res => res.data)
+      .then(data => {
+        this.id = data.id;
+        this.channel = data.channel;
+        this.author = data.author;
+        this.content = data.content;
+        this.downloadLink = data.downloadLink;
+        this.downloadLinkFromSlack = data.downloadLinkFromSlack;
+        this.createdDate = data.createdDate;
+      });
+  },
+  computed: {
+    isLogin() {
+      return this.$store.state.userContext != null;
+    },
+    existMessage() {
+      return this.id != null;
+    }
+  }
 };
 </script>

--- a/src/acceptance-test/java/woowacrew/article/slack/controller/SlackMessageApiControllerTest.java
+++ b/src/acceptance-test/java/woowacrew/article/slack/controller/SlackMessageApiControllerTest.java
@@ -1,5 +1,6 @@
 package woowacrew.article.slack.controller;
 
+import org.hamcrest.Matchers;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -9,8 +10,10 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 import woowacrew.article.slack.TestSlackConfig;
+import woowacrew.article.slack.dto.SlackMessageResponseDto;
 import woowacrew.common.controller.CommonTestController;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
@@ -20,6 +23,40 @@ class SlackMessageApiControllerTest extends CommonTestController {
 
     @Autowired
     private TestSlackConfig slackConfig;
+
+    private JSONObject requestSlackMessageFromBot(String channelId, String authorId) throws JSONException {
+        JSONObject result = requestSlackMessage(channelId, authorId);
+        JSONObject event = (JSONObject) result.get("event");
+
+        event.put("bot_profile", "I am bot");
+        result.put("event", event);
+        return result;
+    }
+
+    private JSONObject requestSlackMessage(String channelId, String authorId) throws JSONException {
+        JSONObject result = new JSONObject();
+
+        JSONObject event = new JSONObject();
+        event.put("text", "good");
+        event.put("user", authorId);
+        event.put("channel", channelId);
+
+        result.put("event", event);
+        return result;
+    }
+
+    private JSONObject requestSlackMessageWithFile(String channelId, String authorId) throws JSONException {
+        JSONObject result = requestSlackMessage(channelId, authorId);
+        JSONObject event = (JSONObject) result.get("event");
+
+        JSONObject file = new JSONObject();
+        file.put("url_private_download", "test.com");
+        file.put("permalink", "test2.com");
+
+        event.put("files", file);
+        result.put("event", event);
+        return result;
+    }
 
     @Test
     @DisplayName("정상적으로 슬랙 메시지를 저장한다.")
@@ -101,37 +138,31 @@ class SlackMessageApiControllerTest extends CommonTestController {
                 .expectStatus().isBadRequest();
     }
 
-    private JSONObject requestSlackMessageFromBot(String channelId, String authorId) throws JSONException {
-        JSONObject result = requestSlackMessage(channelId, authorId);
-        JSONObject event = (JSONObject) result.get("event");
+    @Test
+    @DisplayName("최근 슬랙 메세지를 가져온다.")
+    void findRecentlyMessage() {
+        String cookie = loginWithCrew();
 
-        event.put("bot_profile", "I am bot");
-        result.put("event", event);
-        return result;
+        SlackMessageResponseDto result = webTestClient.get()
+                .uri("/api/slack/notice")
+                .header("Cookie", cookie)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(SlackMessageResponseDto.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertNotNull(result);
     }
 
-    private JSONObject requestSlackMessage(String channelId, String authorId) throws JSONException {
-        JSONObject result = new JSONObject();
-
-        JSONObject event = new JSONObject();
-        event.put("text", "good");
-        event.put("user", authorId);
-        event.put("channel", channelId);
-
-        result.put("event", event);
-        return result;
-    }
-
-    private JSONObject requestSlackMessageWithFile(String channelId, String authorId) throws JSONException {
-        JSONObject result = requestSlackMessage(channelId, authorId);
-        JSONObject event = (JSONObject) result.get("event");
-
-        JSONObject file = new JSONObject();
-        file.put("url_private_download", "test.com");
-        file.put("permalink", "test2.com");
-
-        event.put("files", file);
-        result.put("event", event);
-        return result;
+    @Test
+    @DisplayName("로그인을 하지 않으면 최근 슬랙 메세지를 가져오는데 실패한다.")
+    void findRecentlyMessageFail() {
+        webTestClient.get()
+                .uri("/api/slack/notice")
+                .exchange()
+                .expectStatus().is3xxRedirection()
+                .expectHeader()
+                .value("Location", Matchers.containsString("/login"));
     }
 }

--- a/src/main/java/woowacrew/article/slack/controller/SlackMessageApiController.java
+++ b/src/main/java/woowacrew/article/slack/controller/SlackMessageApiController.java
@@ -3,6 +3,7 @@ package woowacrew.article.slack.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import woowacrew.article.slack.dto.SlackMessageRequestDto;
@@ -17,6 +18,12 @@ public class SlackMessageApiController {
 
     public SlackMessageApiController(SlackMessageService slackMessageService) {
         this.slackMessageService = slackMessageService;
+    }
+
+    @GetMapping("/api/slack/notice")
+    public ResponseEntity<SlackMessageResponseDto> notice() {
+        SlackMessageResponseDto slackMessage = slackMessageService.findRecentlyMessage();
+        return ResponseEntity.ok(slackMessage);
     }
 
     @PostMapping("/api/slack")

--- a/src/main/java/woowacrew/article/slack/controller/SlackMessageApiControllerAdvice.java
+++ b/src/main/java/woowacrew/article/slack/controller/SlackMessageApiControllerAdvice.java
@@ -1,0 +1,14 @@
+package woowacrew.article.slack.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import woowacrew.article.slack.exception.NotFoundRecentlySlackMessageException;
+
+@ControllerAdvice
+public class SlackMessageApiControllerAdvice {
+    @ExceptionHandler(NotFoundRecentlySlackMessageException.class)
+    public ResponseEntity<Void> notFound() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/woowacrew/article/slack/domain/SlackMessage.java
+++ b/src/main/java/woowacrew/article/slack/domain/SlackMessage.java
@@ -1,10 +1,13 @@
 package woowacrew.article.slack.domain;
 
+import woowacrew.common.domain.TimeEntity;
+
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-public class SlackMessage {
+public class SlackMessage extends TimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -31,6 +34,10 @@ public class SlackMessage {
         this.slackFile = new SlackFile(downloadLink, downloadLinkFromSlack);
     }
 
+    public boolean existSlackFile() {
+        return slackFile != null;
+    }
+
     public Long getId() {
         return id;
     }
@@ -53,6 +60,10 @@ public class SlackMessage {
 
     public String getDownloadLinkFromSlack() {
         return slackFile.getDownloadLinkFromSlack();
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
     }
 
     @Override

--- a/src/main/java/woowacrew/article/slack/domain/SlackMessageRepository.java
+++ b/src/main/java/woowacrew/article/slack/domain/SlackMessageRepository.java
@@ -2,5 +2,8 @@ package woowacrew.article.slack.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SlackMessageRepository extends JpaRepository<SlackMessage, Long> {
+    Optional<SlackMessage> findFirstByOrderByCreatedDateDesc();
 }

--- a/src/main/java/woowacrew/article/slack/dto/SlackMessageResponseDto.java
+++ b/src/main/java/woowacrew/article/slack/dto/SlackMessageResponseDto.java
@@ -11,6 +11,10 @@ public class SlackMessageResponseDto {
     private SlackMessageResponseDto() {
     }
 
+    public SlackMessageResponseDto(Long id, String channel, String author, String content) {
+        this(id, channel, author, content, null, null);
+    }
+
     public SlackMessageResponseDto(Long id, String channel, String author, String content, String downloadLink, String downloadLinkFromSlack) {
         this.id = id;
         this.channel = channel;

--- a/src/main/java/woowacrew/article/slack/exception/NotFoundRecentlySlackMessageException.java
+++ b/src/main/java/woowacrew/article/slack/exception/NotFoundRecentlySlackMessageException.java
@@ -1,0 +1,7 @@
+package woowacrew.article.slack.exception;
+
+public class NotFoundRecentlySlackMessageException extends RuntimeException {
+    public NotFoundRecentlySlackMessageException() {
+        super("최근 슬랙 메세지가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/woowacrew/article/slack/service/SlackMessageInternalService.java
+++ b/src/main/java/woowacrew/article/slack/service/SlackMessageInternalService.java
@@ -62,4 +62,10 @@ public class SlackMessageInternalService {
         return slackMessageRepository.findById(id)
                 .orElseThrow(NotFoundSlackMessageException::new);
     }
+
+    @Transactional(readOnly = true)
+    public SlackMessage findRecentlyMessage() {
+        return slackMessageRepository.findFirstByOrderByCreatedDateDesc()
+                .orElseThrow(NotFoundSlackMessageException::new);
+    }
 }

--- a/src/main/java/woowacrew/article/slack/service/SlackMessageInternalService.java
+++ b/src/main/java/woowacrew/article/slack/service/SlackMessageInternalService.java
@@ -15,6 +15,7 @@ import woowacrew.article.slack.domain.SlackMessage;
 import woowacrew.article.slack.domain.SlackMessageRepository;
 import woowacrew.article.slack.dto.SlackMessageRequestDto;
 import woowacrew.article.slack.exception.CreateSlackMessageFailException;
+import woowacrew.article.slack.exception.NotFoundRecentlySlackMessageException;
 import woowacrew.article.slack.exception.NotFoundSlackMessageException;
 import woowacrew.article.slack.utils.SlackMessageConverter;
 
@@ -66,6 +67,6 @@ public class SlackMessageInternalService {
     @Transactional(readOnly = true)
     public SlackMessage findRecentlyMessage() {
         return slackMessageRepository.findFirstByOrderByCreatedDateDesc()
-                .orElseThrow(NotFoundSlackMessageException::new);
+                .orElseThrow(NotFoundRecentlySlackMessageException::new);
     }
 }

--- a/src/main/java/woowacrew/article/slack/service/SlackMessageService.java
+++ b/src/main/java/woowacrew/article/slack/service/SlackMessageService.java
@@ -31,4 +31,9 @@ public class SlackMessageService {
         SlackMessage slackMessage = slackMessageInternalService.findById(id);
         return SlackMessageConverter.toDto(slackMessage);
     }
+
+    public SlackMessageResponseDto findRecentlyMessage() {
+        SlackMessage slackMessage = slackMessageInternalService.findRecentlyMessage();
+        return SlackMessageConverter.toDto(slackMessage);
+    }
 }

--- a/src/main/java/woowacrew/article/slack/utils/SlackMessageConverter.java
+++ b/src/main/java/woowacrew/article/slack/utils/SlackMessageConverter.java
@@ -23,13 +23,16 @@ public class SlackMessageConverter {
     }
 
     public static SlackMessageResponseDto toDto(SlackMessage slackMessage) {
-        return new SlackMessageResponseDto(
-                slackMessage.getId(),
-                slackMessage.getChannel(),
-                slackMessage.getAuthor(),
-                slackMessage.getContent(),
-                slackMessage.getDownloadLink(),
-                slackMessage.getDownloadLinkFromSlack());
+        if (slackMessage.existSlackFile()) {
+            return new SlackMessageResponseDto(
+                    slackMessage.getId(),
+                    slackMessage.getChannel(),
+                    slackMessage.getAuthor(),
+                    slackMessage.getContent(),
+                    slackMessage.getDownloadLink(),
+                    slackMessage.getDownloadLinkFromSlack());
+        }
+        return new SlackMessageResponseDto(slackMessage.getId(), slackMessage.getChannel(), slackMessage.getAuthor(), slackMessage.getContent());
     }
 
     public static SlackMessageResponseDtos toDtos(Page<SlackMessage> slackMessages) {

--- a/src/test/java/woowacrew/article/slack/service/SlackMessageInternalServiceTest.java
+++ b/src/test/java/woowacrew/article/slack/service/SlackMessageInternalServiceTest.java
@@ -129,4 +129,13 @@ class SlackMessageInternalServiceTest {
 
         assertThrows(NotFoundSlackMessageException.class, () -> slackMessageInternalService.findById(1L));
     }
+
+    @Test
+    @DisplayName("최근 슬랙 메세지를 가져온다.")
+    void findRecentlyMessage() {
+        SlackMessage slackMessage = saveSlackMessage(testSlackConfig.getToken(), testSlackConfig.getChannelId(), testSlackConfig.getAuthorId());
+        when(slackMessageRepository.findFirstByOrderByCreatedDateDesc()).thenReturn(Optional.ofNullable(slackMessage));
+
+        assertThat(slackMessageInternalService.findRecentlyMessage()).isEqualTo(slackMessage);
+    }
 }

--- a/src/test/java/woowacrew/article/slack/service/SlackMessageInternalServiceTest.java
+++ b/src/test/java/woowacrew/article/slack/service/SlackMessageInternalServiceTest.java
@@ -14,6 +14,7 @@ import woowacrew.article.slack.domain.SlackMessage;
 import woowacrew.article.slack.domain.SlackMessageRepository;
 import woowacrew.article.slack.dto.SlackMessageRequestDto;
 import woowacrew.article.slack.exception.CreateSlackMessageFailException;
+import woowacrew.article.slack.exception.NotFoundRecentlySlackMessageException;
 import woowacrew.article.slack.exception.NotFoundSlackMessageException;
 import woowacrew.article.slack.utils.SlackMessageConverter;
 
@@ -137,5 +138,13 @@ class SlackMessageInternalServiceTest {
         when(slackMessageRepository.findFirstByOrderByCreatedDateDesc()).thenReturn(Optional.ofNullable(slackMessage));
 
         assertThat(slackMessageInternalService.findRecentlyMessage()).isEqualTo(slackMessage);
+    }
+
+    @Test
+    @DisplayName("최근 슬랙 메세지가 없는 경우, 예외가 발생한다.")
+    void notFoundRecentlySlackMessage() {
+        when(slackMessageRepository.findFirstByOrderByCreatedDateDesc()).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundRecentlySlackMessageException.class, () -> slackMessageInternalService.findRecentlyMessage());
     }
 }

--- a/src/test/java/woowacrew/article/slack/service/SlackMessageServiceTest.java
+++ b/src/test/java/woowacrew/article/slack/service/SlackMessageServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -83,5 +84,15 @@ class SlackMessageServiceTest {
         assertThat(result.getContent()).isEqualTo(slackMessage.getContent());
         assertThat(result.getDownloadLink()).isEqualTo(slackMessage.getDownloadLink());
         assertThat(result.getDownloadLinkFromSlack()).isEqualTo(slackMessage.getDownloadLinkFromSlack());
+    }
+
+    @Test
+    @DisplayName("정상적으로 최근 슬랙 메세지를 가져온다.")
+    void findRecentlyMessage() {
+        SlackMessage slackMessage = createSlackMessages(1).get(0);
+
+        when(slackMessageInternalService.findRecentlyMessage()).thenReturn(slackMessage);
+
+        assertNotNull(slackMessageService.findRecentlyMessage());
     }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -103,4 +103,6 @@ INSERT INTO anonymous_article (id, title, content, signing_key, is_approved) VAL
 INSERT INTO anonymous_article (id, title, content, signing_key, is_approved) VALUES (5, 'title', 'content', 'password', false);
 
 
-INSERT INTO slack_message (id, channel, author, content, download_link, download_link_from_slack) VALUES (1, 'testChannel', 'testAuthor', 'testContent', 'test.com', 'test2.com');
+INSERT INTO slack_message (id, channel, author, content, download_link, download_link_from_slack, created_date) VALUES (1, 'testChannel', 'testAuthor', 'testContent', 'test.com', 'test2.com', '2019-10-09T00:00:01');
+INSERT INTO slack_message (id, channel, author, content, download_link, download_link_from_slack, created_date) VALUES (2, 'testChannel2', 'testAuthor', 'testContent', 'test.com', 'test2.com', '2019-10-09T00:00:02');
+INSERT INTO slack_message (id, channel, author, content, download_link, download_link_from_slack, created_date) VALUES (3, 'testChannel3', 'testAuthor', 'testContent', 'test.com', 'test2.com', '2019-10-09T00:00:03');


### PR DESCRIPTION
resolved #306 

- 로그인 하지 않았을 경우, "로그인이 필요합니다" 메세지 노출
- 최근 슬랙 메세지가 없는 경우, "최근 슬랙 메세지가 존재하지 않습니다." 메세지 노출
- 다운로드 링크가 없는 경우, 다운로드 영역 제거