### PR TITLE
test: 실패하는 테스트 수정

### DIFF
--- a/src/acceptance-test/java/woowacrew/article/slack/controller/SlackMessageApiControllerMockTest.java
+++ b/src/acceptance-test/java/woowacrew/article/slack/controller/SlackMessageApiControllerMockTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -24,9 +25,11 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static woowacrew.article.slack.controller.SlackMessageApiControllerTest.requestSlackMessage;
 import static woowacrew.article.slack.controller.SlackMessageApiControllerTest.requestSlackMessageWithFile;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 public class SlackMessageApiControllerMockTest {
+
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/acceptance-test/java/woowacrew/feed/controller/FeedApiControllerTest.java
+++ b/src/acceptance-test/java/woowacrew/feed/controller/FeedApiControllerTest.java
@@ -2,6 +2,7 @@ package woowacrew.feed.controller;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -18,6 +19,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
+@AutoConfigureWebTestClient(timeout = "40000")
 public class FeedApiControllerTest extends CommonTestController {
 
     @Test

--- a/src/acceptance-test/java/woowacrew/keyword/controller/SearchApiControllerTest.java
+++ b/src/acceptance-test/java/woowacrew/keyword/controller/SearchApiControllerTest.java
@@ -2,8 +2,7 @@ package woowacrew.keyword.controller;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.web.reactive.function.BodyInserters;
 import woowacrew.common.controller.CommonTestController;
 import woowacrew.keyword.domain.KeywordResponseDto;
@@ -13,9 +12,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SearchApiControllerTest extends CommonTestController {
-
-    @Autowired
-    private WebTestClient webTestClient;
 
     @Test
     void 정상적으로_검색어를_저장한다() {
@@ -41,6 +37,7 @@ public class SearchApiControllerTest extends CommonTestController {
     }
 
     @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
     void 검색어_순위를_가져온다() {
         String cookie = loginWithCrew();
 

--- a/src/acceptance-test/java/woowacrew/keyword/controller/SearchControllerTest.java
+++ b/src/acceptance-test/java/woowacrew/keyword/controller/SearchControllerTest.java
@@ -1,45 +1,17 @@
 package woowacrew.keyword.controller;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import woowacrew.common.controller.CommonTestController;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
 
-@ExtendWith(RestDocumentationExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class SearchControllerTest {
-
-    @LocalServerPort
-    private String port;
-
-    @Autowired
-    private WebTestClient webTestClient;
-
-    @BeforeEach
-    void setUp(RestDocumentationContextProvider restDocumentation) {
-        webTestClient = WebTestClient.bindToServer()
-                .baseUrl("http://localhost:" + port)
-                .filter(documentationConfiguration(restDocumentation))
-                .build();
-    }
+class SearchControllerTest extends CommonTestController {
 
     @Test
     void 검색어를_정상적으로_저장한다() {


### PR DESCRIPTION
1. CommonTestController를 상속받고 있는 않는 테스트 class에 @activeprofiles("test") 붙이니 해결
    - 검색어 관련된 테스트 클래스에 @activeprofiles("test")가 붙어있지 않았습니다.

2. FeedApiController에 timeout 에러가 1번씩 나오는데 기본값 (5000)에서 20000으로 설정
    - push 하면 가끔 실패하는 테스트가 가끔 나오는데 FeedApiController에서 timeout 문제인거 같다는 생각입니다. 그래서 40000으로 다시 설정
    - timeout을 많이 늘리는거에 있어서 문제점은 알아보고, 다시 수정하겠습니다.