### PR TITLE
feat: 커밋 정보 저장하기

### DIFF
--- a/woowacrew-domain/build.gradle
+++ b/woowacrew-domain/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'com.rometools:rome:1.12.0'
     implementation 'com.ullink.slack:simpleslackapi:1.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.jsoup:jsoup:1.11.3'
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
 
     runtimeOnly 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -23,7 +23,7 @@ public class GithubCommit {
         this.point = point;
     }
 
-    public void validateDate(LocalDate date) {
+    private void validateDate(LocalDate date) {
         if (date.getDayOfMonth() != 1) {
             throw new RuntimeException();
         }

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -1,0 +1,31 @@
+package woowacrew.github.domain;
+
+import woowacrew.user.domain.User;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+public class GithubCommit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private User user;
+    private LocalDate date;
+    private Integer point;
+
+    public GithubCommit(User user, LocalDate date, Integer point) {
+        validateDate(date);
+        this.user = user;
+        this.date = date;
+        this.point = point;
+    }
+
+    public void validateDate(LocalDate date) {
+        if (date.getDayOfMonth() != 1) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
@@ -1,0 +1,8 @@
+package woowacrew.github.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GithubCommitRepository extends JpaRepository<GithubCommit, Long> {
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/dto/GithubCommitRequestDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/dto/GithubCommitRequestDto.java
@@ -1,0 +1,20 @@
+package woowacrew.github.dto;
+
+public class GithubCommitRequestDto {
+
+    private int year;
+    private int month;
+
+    public GithubCommitRequestDto(int year, int month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/dto/GithubCommitStateDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/dto/GithubCommitStateDto.java
@@ -1,0 +1,25 @@
+package woowacrew.github.dto;
+
+import java.time.LocalDate;
+
+public class GithubCommitStateDto {
+
+    private LocalDate date;
+    private int commitCount;
+
+    private GithubCommitStateDto() {
+    }
+
+    public GithubCommitStateDto(LocalDate date, int commitCount) {
+        this.date = date;
+        this.commitCount = commitCount;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public int getCommitCount() {
+        return commitCount;
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/exception/DateRangeException.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/exception/DateRangeException.java
@@ -1,0 +1,7 @@
+package woowacrew.github.exception;
+
+public class DateRangeException extends RuntimeException {
+    public DateRangeException() {
+        super("해당 날짜는 범위에 벗어난 날짜 입니다.");
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/exception/GithubCommitCrawlingFailException.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/exception/GithubCommitCrawlingFailException.java
@@ -1,0 +1,7 @@
+package woowacrew.github.exception;
+
+public class GithubCommitCrawlingFailException extends RuntimeException {
+    public GithubCommitCrawlingFailException() {
+        super("Github 커밋 정보를 크롤링하는데 실패하였습니다.");
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
@@ -1,0 +1,77 @@
+package woowacrew.github.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import woowacrew.github.dto.GithubCommitStateDto;
+import woowacrew.github.exception.DateRangeException;
+import woowacrew.github.exception.GithubCommitCrawlingFailException;
+import woowacrew.github.utils.GithubCommitStateConverter;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class GithubCommitCrawlingService {
+
+    private static final Logger log = LoggerFactory.getLogger(GithubCommitCrawlingService.class);
+    private static final String GITHUB_DOMAIN = "https://github.com/";
+
+    public List<GithubCommitStateDto> fetchCommitState(String githubId, LocalDate currentDate) {
+        try {
+            Elements fullCommitState = this.fetchFullCommitState(githubId);
+            this.checkContainsDate(fullCommitState, currentDate);
+            return this.getCommitState(fullCommitState, currentDate.getYear(), currentDate.getMonthValue());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new GithubCommitCrawlingFailException();
+        }
+    }
+
+    private Elements fetchFullCommitState(String githubId) throws IOException {
+        String url = GITHUB_DOMAIN + githubId;
+        Document document = Jsoup.connect(url).get();
+        return document.getElementsByTag("g").get(0).getElementsByClass("day");
+    }
+
+    private void checkContainsDate(Elements fullCommitState, LocalDate currentDate) {
+        int firstIndex = 0;
+        int lastIndex = fullCommitState.size() - 1;
+
+        LocalDate startDate = getDate(fullCommitState, firstIndex);
+        LocalDate endDate = getDate(fullCommitState, lastIndex);
+        if (!isContainsDate(currentDate, startDate, endDate)) {
+            throw new DateRangeException();
+        }
+    }
+
+    private LocalDate getDate(Elements fullCommitState, int index) {
+        return LocalDate.parse(fullCommitState.get(index).attr("data-date"));
+    }
+
+    private boolean isContainsDate(LocalDate currentDate, LocalDate startDate, LocalDate endDate) {
+        if (currentDate.isEqual(startDate) || currentDate.isEqual(endDate)) {
+            return true;
+        }
+        return currentDate.isAfter(startDate) && currentDate.isBefore(endDate);
+    }
+
+    private List<GithubCommitStateDto> getCommitState(Elements fullDate, int currentYear, int currentMonth) {
+        return fullDate.stream()
+                .map(GithubCommitStateConverter::toDto)
+                .filter(data -> isSameYearAndMonth(data.getDate(), currentYear, currentMonth))
+                .sorted(Comparator.comparing(GithubCommitStateDto::getDate))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isSameYearAndMonth(LocalDate date, int currentYear, int currentMonth) {
+        return date.getYear() == currentYear && date.getMonthValue() == currentMonth;
+    }
+}
+

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
@@ -23,11 +23,11 @@ public class GithubCommitCrawlingService {
     private static final Logger log = LoggerFactory.getLogger(GithubCommitCrawlingService.class);
     private static final String GITHUB_DOMAIN = "https://github.com/";
 
-    public List<GithubCommitStateDto> fetchCommitState(String githubId, LocalDate currentDate) {
+    public List<GithubCommitStateDto> fetchCommitState(String githubId, LocalDate date) {
         try {
             Elements fullCommitState = this.fetchFullCommitState(githubId);
-            this.checkContainsDate(fullCommitState, currentDate);
-            return this.getCommitState(fullCommitState, currentDate.getYear(), currentDate.getMonthValue());
+            this.checkContainsDate(fullCommitState, date);
+            return this.getCommitState(fullCommitState, date.getYear(), date.getMonthValue());
         } catch (Exception e) {
             log.error(e.getMessage());
             throw new GithubCommitCrawlingFailException();
@@ -40,13 +40,13 @@ public class GithubCommitCrawlingService {
         return document.getElementsByTag("g").get(0).getElementsByClass("day");
     }
 
-    private void checkContainsDate(Elements fullCommitState, LocalDate currentDate) {
+    private void checkContainsDate(Elements fullCommitState, LocalDate date) {
         int firstIndex = 0;
         int lastIndex = fullCommitState.size() - 1;
 
         LocalDate startDate = getDate(fullCommitState, firstIndex);
         LocalDate endDate = getDate(fullCommitState, lastIndex);
-        if (!isContainsDate(currentDate, startDate, endDate)) {
+        if (!isContainsDate(date, startDate, endDate)) {
             throw new DateRangeException();
         }
     }
@@ -55,11 +55,11 @@ public class GithubCommitCrawlingService {
         return LocalDate.parse(fullCommitState.get(index).attr("data-date"));
     }
 
-    private boolean isContainsDate(LocalDate currentDate, LocalDate startDate, LocalDate endDate) {
-        if (currentDate.isEqual(startDate) || currentDate.isEqual(endDate)) {
+    private boolean isContainsDate(LocalDate date, LocalDate startDate, LocalDate endDate) {
+        if (date.isEqual(startDate) || date.isEqual(endDate)) {
             return true;
         }
-        return currentDate.isAfter(startDate) && currentDate.isBefore(endDate);
+        return date.isAfter(startDate) && date.isBefore(endDate);
     }
 
     private List<GithubCommitStateDto> getCommitState(Elements fullDate, int currentYear, int currentMonth) {

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
@@ -1,0 +1,37 @@
+package woowacrew.github.service;
+
+import org.springframework.stereotype.Service;
+import woowacrew.github.domain.GithubCommit;
+import woowacrew.github.domain.GithubCommitRepository;
+import woowacrew.github.dto.GithubCommitStateDto;
+import woowacrew.github.utils.GithubCommitCalculator;
+import woowacrew.user.domain.User;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class GithubCommitInternalService {
+
+    private final GithubCommitCrawlingService githubCommitCrawlingService;
+    private final GithubCommitRepository githubCommitRepository;
+
+    public GithubCommitInternalService(GithubCommitCrawlingService githubCommitCrawlingService, GithubCommitRepository githubCommitRepository) {
+        this.githubCommitCrawlingService = githubCommitCrawlingService;
+        this.githubCommitRepository = githubCommitRepository;
+    }
+
+    @Transactional
+    public void save(List<User> users, LocalDate date) {
+        for (User user : users) {
+            int point = calculateCommitPoint(user.getGithubId(), date);
+            this.githubCommitRepository.save(new GithubCommit(user, date, point));
+        }
+    }
+
+    public int calculateCommitPoint(String githubId, LocalDate date) {
+        List<GithubCommitStateDto> commitState = githubCommitCrawlingService.fetchCommitState(githubId, date);
+        return GithubCommitCalculator.calculate(commitState);
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitCalculator.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitCalculator.java
@@ -1,0 +1,48 @@
+package woowacrew.github.utils;
+
+import woowacrew.github.dto.GithubCommitStateDto;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 1. 커밋 개수 1개마다 10점을 부여한다.
+ * 2. 매일 커밋할 때마다 x2, x4, x8 까지 곱한다.
+ * 3. 커밋이 없다면 다시 x2부터 시작한다.
+ * ex) x2, x4, x8, x8, x8, x2, x4 ...
+ */
+public class GithubCommitCalculator {
+
+    private static final int MIN_BONUS_POINT = 0;
+    private static final int MAX_BONUS_POINT = 3;
+
+    private GithubCommitCalculator() {
+    }
+
+    public static int calculate(List<GithubCommitStateDto> commitState) {
+        AtomicInteger bonusPoint = new AtomicInteger(MIN_BONUS_POINT);
+        return commitState.stream()
+                .map(GithubCommitStateDto::getCommitCount)
+                .mapToInt(commitCount -> {
+                    bonusPoint.set(getBonusPoint(commitCount, bonusPoint.get()));
+                    return calculate(commitCount, bonusPoint.get());
+                })
+                .sum();
+    }
+
+    private static int calculate(int commitCount, int bonusPoint) {
+        bonusPoint = (int) Math.pow(2, bonusPoint);
+        return (commitCount * 10) * bonusPoint;
+    }
+
+    private static int getBonusPoint(int commitCount, int bonusPoint) {
+        if (isEmptyCommit(commitCount)) {
+            return MIN_BONUS_POINT;
+        }
+        return bonusPoint == MAX_BONUS_POINT ? bonusPoint : bonusPoint + 1;
+    }
+
+    private static boolean isEmptyCommit(int commitCount) {
+        return commitCount == 0;
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitStateConverter.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitStateConverter.java
@@ -1,0 +1,18 @@
+package woowacrew.github.utils;
+
+import org.jsoup.nodes.Element;
+import woowacrew.github.dto.GithubCommitStateDto;
+
+import java.time.LocalDate;
+
+public class GithubCommitStateConverter {
+
+    private GithubCommitStateConverter() {
+    }
+
+    public static GithubCommitStateDto toDto(Element element) {
+        LocalDate date = LocalDate.parse(element.attr("data-date"));
+        int commitCount = Integer.parseInt(element.attr("data-count"));
+        return new GithubCommitStateDto(date, commitCount);
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/user/domain/User.java
+++ b/woowacrew-domain/src/main/java/woowacrew/user/domain/User.java
@@ -17,6 +17,8 @@ public class User {
 
     private String oauthId;
 
+    private String githubId;
+
     private String nickname;
 
     private LocalDate birthday;
@@ -38,6 +40,13 @@ public class User {
     public User(String oauthId, UserRole role, Degree degree) {
         this.oauthId = oauthId;
         this.role = role;
+        this.degree = degree;
+    }
+
+    public User(String oauthId, String githubId, Degree degree) {
+        this.oauthId = oauthId;
+        this.githubId = githubId;
+        this.role = UserRole.ROLE_PRECOURSE;
         this.degree = degree;
     }
 
@@ -99,6 +108,8 @@ public class User {
     public String getOauthId() {
         return oauthId;
     }
+
+    public String getGithubId() { return githubId; }
 
     public String getNickname() {
         return nickname;

--- a/woowacrew-domain/src/main/java/woowacrew/user/domain/UserRepository.java
+++ b/woowacrew-domain/src/main/java/woowacrew/user/domain/UserRepository.java
@@ -16,5 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findByDegreeIdAndNicknameNotNull(Long degreeId);
 
+    List<User> findByGithubIdIsNotNull();
+
     int countByDegreeIdAndNicknameNotNull(Long degreeId);
 }

--- a/woowacrew-domain/src/main/java/woowacrew/user/dto/UserOauthDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/user/dto/UserOauthDto.java
@@ -6,18 +6,27 @@ public class UserOauthDto {
     @SerializedName("id")
     private String oauthId;
 
-    public UserOauthDto(String oauthId) {
+    @SerializedName("login")
+    private String githubId;
+
+    public UserOauthDto(String oauthId, String githubId) {
         this.oauthId = oauthId;
+        this.githubId = githubId;
     }
 
     public String getOauthId() {
         return oauthId;
     }
 
+    public String getGithubId() {
+        return githubId;
+    }
+
     @Override
     public String toString() {
         return "UserOauthDto{" +
                 "oauthId='" + oauthId + '\'' +
+                ", githubId='" + githubId + '\'' +
                 '}';
     }
 }

--- a/woowacrew-domain/src/main/java/woowacrew/user/service/UserInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/user/service/UserInternalService.java
@@ -102,4 +102,8 @@ public class UserInternalService {
                 .map(User::getGithubId)
                 .collect(Collectors.toList());
     }
+
+    public List<User> findByGithubIdIsNotNull() {
+        return userRepository.findByGithubIdIsNotNull();
+    }
 }

--- a/woowacrew-domain/src/main/java/woowacrew/user/service/UserInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/user/service/UserInternalService.java
@@ -95,4 +95,11 @@ public class UserInternalService {
 
         return userRepository.save(user);
     }
+
+    public List<String> findAllGithubId() {
+        return userRepository.findByGithubIdIsNotNull()
+                .stream()
+                .map(User::getGithubId)
+                .collect(Collectors.toList());
+    }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
@@ -1,0 +1,31 @@
+package woowacrew.github.domain;
+
+import org.junit.jupiter.api.Test;
+import woowacrew.user.domain.User;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class GithubCommitTest {
+
+    @Test
+    void 정상적으로_GitubCommit을_생성한다() {
+        User mockUser = mock(User.class);
+        LocalDate date = LocalDate.of(2020, 6, 1);
+        GithubCommit result = new GithubCommit(mockUser, date, 300);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void 날짜가_1일이_아니면_예외가_발생한다() {
+        assertThrows(RuntimeException.class, () -> {
+            User mockUser = mock(User.class);
+            LocalDate date = LocalDate.of(2020, 6, 2);
+            new GithubCommit(mockUser, date, 300);
+        });
+    }
+}

--- a/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
@@ -1,0 +1,70 @@
+package woowacrew.github.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import woowacrew.github.domain.GithubCommitRepository;
+import woowacrew.github.dto.GithubCommitStateDto;
+import woowacrew.user.domain.User;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GithubCommitInternalServiceTest {
+
+    @Mock
+    private GithubCommitCrawlingService githubCommitCrawlingService;
+
+    @Mock
+    private GithubCommitRepository githubCommitRepository;
+
+    @InjectMocks
+    private GithubCommitInternalService githubCommitInternalService;
+
+    private static List<GithubCommitStateDto> createGithubCommitStateDto(LocalDate date) {
+        List<GithubCommitStateDto> result = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            result.add(new GithubCommitStateDto(date, 1));
+        }
+        return result;
+    }
+
+    @Test
+    void 정상적으로_커밋_점수를_계산한다() {
+        String githubId = "hyojaekim";
+        LocalDate date = LocalDate.of(2020, 6, 1);
+        List<GithubCommitStateDto> commitState = createGithubCommitStateDto(date);
+
+        when(githubCommitCrawlingService.fetchCommitState(githubId, date)).thenReturn(commitState);
+
+        assertThat(githubCommitInternalService.calculateCommitPoint(githubId, date)).isEqualTo(300);
+    }
+
+    @Test
+    void 모든_유저의_커밋_점수를_저장한다() {
+        LocalDate date = LocalDate.of(2020, 6, 1);
+        List<GithubCommitStateDto> commitState = createGithubCommitStateDto(date);
+        User mockUser = mock(User.class);
+        List<User> users = new ArrayList<>();
+        users.add(mockUser);
+        users.add(mockUser);
+        users.add(mockUser);
+        users.add(mockUser);
+
+        when(mockUser.getGithubId()).thenReturn("githubId");
+        when(githubCommitCrawlingService.fetchCommitState(anyString(), any())).thenReturn(commitState);
+
+        githubCommitInternalService.save(users, date);
+
+        verify(githubCommitRepository, times(users.size())).save(any());
+    }
+}

--- a/woowacrew-domain/src/test/java/woowacrew/github/utils/GithubCommitCalculatorTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/utils/GithubCommitCalculatorTest.java
@@ -1,0 +1,32 @@
+package woowacrew.github.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import woowacrew.github.dto.GithubCommitStateDto;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GithubCommitCalculatorTest {
+
+    private List<GithubCommitStateDto> commitStateResult;
+
+    @BeforeEach
+    void setUp() {
+        this.commitStateResult = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            GithubCommitStateDto githubCommitStateDto = new GithubCommitStateDto(LocalDate.now(), 1);
+            this.commitStateResult.add(githubCommitStateDto);
+        }
+    }
+
+    @Test
+    void 정상적으로_커밋_점수를_계산한다() {
+        int calculate = GithubCommitCalculator.calculate(commitStateResult);
+
+        assertThat(calculate).isEqualTo(700);
+    }
+}

--- a/woowacrew-domain/src/test/java/woowacrew/github/utils/GithubCommitStateConverterTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/utils/GithubCommitStateConverterTest.java
@@ -1,0 +1,35 @@
+package woowacrew.github.utils;
+
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import woowacrew.github.dto.GithubCommitStateDto;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GithubCommitStateConverterTest {
+
+    private Element element;
+
+    @BeforeEach
+    void setUp() {
+        Attributes attributes = new Attributes();
+        attributes.put("data-date", "2019-07-07");
+        attributes.put("data-count", "3");
+
+        Tag tag = Tag.valueOf("rect");
+        this.element = new Element(tag, "https://github.com/hyojaekim", attributes);
+    }
+
+    @Test
+    void 정상적으로_DTO로_변환한다() {
+        GithubCommitStateDto result = GithubCommitStateConverter.toDto(element);
+
+        assertThat(result.getCommitCount()).isEqualTo(3);
+        assertThat(result.getDate()).isEqualTo(LocalDate.of(2019, 7, 7));
+    }
+}

--- a/woowacrew-domain/src/test/java/woowacrew/user/domain/UserRepositoryTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/user/domain/UserRepositoryTest.java
@@ -62,4 +62,11 @@ class UserRepositoryTest {
 
         assertThat(numberOfUser).isNotZero();
     }
+
+    @Test
+    void 깃헙_아이디가_있으면_가져온다() {
+        List<User> result = userRepository.findByGithubIdIsNotNull();
+
+        assertThat(result.size()).isNotZero();
+    }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/user/service/UserInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/user/service/UserInternalServiceTest.java
@@ -110,4 +110,17 @@ class UserInternalServiceTest {
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0)).isEqualTo("githubId");
     }
+
+    @Test
+    @DisplayName("깃헙 아이디가 존재하는 유저를 모두 가져온다")
+    void findByGithubIdIsNotNull() {
+        List<User> users = Arrays.asList(new User("oauthId", "githubId", new Degree()));
+
+        when(userRepository.findByGithubIdIsNotNull()).thenReturn(users);
+
+        List<User> result = userInternalService.findByGithubIdIsNotNull();
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getGithubId()).isEqualTo("githubId");
+    }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/user/service/UserInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/user/service/UserInternalServiceTest.java
@@ -97,4 +97,17 @@ class UserInternalServiceTest {
             assertTrue(user.isBirthday(today));
         }
     }
+
+    @Test
+    @DisplayName("유저의 모든 깃헙 아이디를 가져온다.")
+    void findAllGithubId() {
+        List<User> users = Arrays.asList(new User("oauthId", "githubId", new Degree()));
+
+        when(userRepository.findByGithubIdIsNotNull()).thenReturn(users);
+
+        List<String> result = userInternalService.findAllGithubId();
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo("githubId");
+    }
 }

--- a/woowacrew-domain/src/test/resources/data.sql
+++ b/woowacrew-domain/src/test/resources/data.sql
@@ -80,6 +80,7 @@ INSERT INTO user (id, oauth_id, nickname, role, degree_id, birthday) VALUES (9, 
 INSERT INTO user (id, oauth_id, nickname, role, degree_id, birthday) VALUES (10, '11','woowacrew2','ROLE_PRECOURSE', 1, '1995-05-20');
 INSERT INTO user (id, oauth_id, nickname, role, degree_id, birthday) VALUES (11, '12','woowacrew3','ROLE_PRECOURSE', 1, '1995-06-12');
 INSERT INTO user (id, oauth_id, nickname, role, degree_id, birthday) VALUES (12, '12','woowacrew3','ROLE_PRECOURSE', 1, '1995-06-08');
+INSERT INTO user (id, oauth_id, nickname, role, degree_id, github_id) VALUES (13, '13','woowacrew4','ROLE_PRECOURSE', 1, 'githubId');
 
 INSERT INTO feed_source(id,source_url,description) values (1,'https://vsh123.github.io/feed.xml', 'SHAKEVAN');
 INSERT INTO feed_source(id,source_url,description) values (2,'https://jojoldu.tistory.com/feed', 'TEST');

--- a/woowacrew-web/src/main/java/woowacrew/WoowaCrewApplication.java
+++ b/woowacrew-web/src/main/java/woowacrew/WoowaCrewApplication.java
@@ -2,7 +2,9 @@ package woowacrew;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class WoowaCrewApplication {
     public static void main(String[] args) {

--- a/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitSchedulerService.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitSchedulerService.java
@@ -1,0 +1,24 @@
+package woowacrew.github.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import woowacrew.github.dto.GithubCommitRequestDto;
+
+import java.time.LocalDate;
+
+@Service
+public class GithubCommitSchedulerService {
+
+    private final GithubCommitService githubCommitService;
+
+    public GithubCommitSchedulerService(GithubCommitService githubCommitService) {
+        this.githubCommitService = githubCommitService;
+    }
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void save() {
+        LocalDate now = LocalDate.now();
+        GithubCommitRequestDto requestDto = new GithubCommitRequestDto(now.getYear(), now.getMonthValue());
+        this.githubCommitService.save(requestDto);
+    }
+}

--- a/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
@@ -1,0 +1,31 @@
+package woowacrew.github.service;
+
+import org.springframework.stereotype.Service;
+import woowacrew.github.dto.GithubCommitRequestDto;
+import woowacrew.user.domain.User;
+import woowacrew.user.service.UserInternalService;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class GithubCommitService {
+
+    private final GithubCommitInternalService githubCommitInternalService;
+    private final UserInternalService userInternalService;
+
+    public GithubCommitService(GithubCommitInternalService githubCommitInternalService, UserInternalService userInternalService) {
+        this.githubCommitInternalService = githubCommitInternalService;
+        this.userInternalService = userInternalService;
+    }
+
+    public void save(GithubCommitRequestDto requestDto) {
+        LocalDate date = createDate(requestDto);
+        List<User> users = this.userInternalService.findByGithubIdIsNotNull();
+        this.githubCommitInternalService.save(users, date);
+    }
+
+    private LocalDate createDate(GithubCommitRequestDto requestDto) {
+        return LocalDate.of(requestDto.getYear(), requestDto.getMonth(), 1);
+    }
+}

--- a/woowacrew-web/src/main/java/woowacrew/security/provider/SocialLoginAuthenticationProvider.java
+++ b/woowacrew-web/src/main/java/woowacrew/security/provider/SocialLoginAuthenticationProvider.java
@@ -48,6 +48,6 @@ public class SocialLoginAuthenticationProvider implements AuthenticationProvider
     private User registerUser(UserOauthDto userOauthDto) {
         Degree degree = degreeRepository.findByDegreeNumber(0)
                 .orElseThrow(DegreeBoundException::new);
-        return userRepository.save(new User(userOauthDto.getOauthId(), degree));
+        return userRepository.save(new User(userOauthDto.getOauthId(), userOauthDto.getGithubId(), degree));
     }
 }

--- a/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
@@ -1,0 +1,34 @@
+package woowacrew.github.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import woowacrew.github.dto.GithubCommitRequestDto;
+import woowacrew.user.service.UserInternalService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GithubCommitServiceTest {
+
+    @Mock
+    private GithubCommitInternalService githubCommitInternalService;
+
+    @Mock
+    private UserInternalService userInternalService;
+
+    @InjectMocks
+    private GithubCommitService githubCommitService;
+
+    @Test
+    void 정상적으로_커밋_정보들을_저장한다() {
+        githubCommitService.save(new GithubCommitRequestDto(2020, 6));
+
+        verify(userInternalService, times(1)).findByGithubIdIsNotNull();
+        verify(githubCommitInternalService, times(1)).save(any(), any());
+    }
+}

--- a/woowacrew-web/src/test/java/woowacrew/security/provider/SocialLoginAuthenticationProviderTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/security/provider/SocialLoginAuthenticationProviderTest.java
@@ -57,12 +57,14 @@ class SocialLoginAuthenticationProviderTest {
         String code = "code";
         String accessToken = "accessToken";
         String userId = "woowacrew";
-        User user = new User(userId, new Degree());
+        String githubId = "githubId";
+
+        User user = new User(userId, githubId, new Degree());
 
         SocialPreAuthorizationToken token = new SocialPreAuthorizationToken(code, code);
 
         when(oauthService.getAccessToken(code)).thenReturn(accessToken);
-        when(oauthService.getUserInfo(accessToken)).thenReturn(new UserOauthDto(userId));
+        when(oauthService.getUserInfo(accessToken)).thenReturn(new UserOauthDto(userId, githubId));
         when(userRepository.findByOauthId(userId)).thenReturn(Optional.ofNullable(user));
 
         SocialPostAuthorizationToken postToken = (SocialPostAuthorizationToken) socialLoginAuthenticationProvider.authenticate(token);
@@ -76,12 +78,14 @@ class SocialLoginAuthenticationProviderTest {
         String code = "code";
         String accessToken = "accessToken";
         String userId = "woowacrew";
-        User user = new User(userId, new Degree());
+        String githubId = "githubId";
+
+        User user = new User(userId, githubId, new Degree());
 
         SocialPreAuthorizationToken token = new SocialPreAuthorizationToken(code, code);
 
         when(oauthService.getAccessToken(code)).thenReturn(accessToken);
-        when(oauthService.getUserInfo(accessToken)).thenReturn(new UserOauthDto(userId));
+        when(oauthService.getUserInfo(accessToken)).thenReturn(new UserOauthDto(userId, githubId));
         when(userRepository.findByOauthId(userId)).thenReturn(Optional.ofNullable(null));
         when(degreeRepository.findByDegreeNumber(anyInt())).thenReturn(Optional.of(new Degree()));
         when(userRepository.save(any())).thenReturn(user);


### PR DESCRIPTION
- 이번 달의 커밋 정보 모두 크롤링
- 점수 계산
  - 커밋 1개마다 10점 부여
  - 매일 커밋할 때마다 x2, x4, x8 까지 곱한다. ex) 5일 연속 커밋 했을 때 -> x2, x4, x8, x8, x8
  - 오늘 커밋이 없는 경우 다시 x2부터 시작
  - 5일 연속 1개씩 커밋 했을 경우
`[1일] (1 x 10) x 2, [2일] (1 x 10) x 4, [3일] (1 x 10) x 8, [4일] (1 x 10) x 8, [5일] (1 x 10) x 8 = 300(20 + 40 + 80 + 80 + 80`
- 오전 9시마다 크루들의 커밋 정보들을 크롤링 후, 점수 계산하고 저장한다.