### PR TITLE
feat: 현재 나의 커밋 랭킹을 조회한다

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2931,7 +2931,7 @@
     },
     "@hapi/bourne": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/@hapi/bourne/download/@hapi/bourne-1.3.2.tgz?cache=0&sync_timestamp=1578129065689&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40hapi%2Fbourne%2Fdownload%2F%40hapi%2Fbourne-1.3.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/@hapi/bourne/download/@hapi/bourne-1.3.2.tgz",
       "integrity": "sha1-CnCVreoGckPOMoPhtWuKj0U7JCo=",
       "dev": true
     },
@@ -2955,7 +2955,7 @@
     },
     "@hapi/topo": {
       "version": "3.1.6",
-      "resolved": "https://registry.npm.taobao.org/@hapi/topo/download/@hapi/topo-3.1.6.tgz?cache=0&sync_timestamp=1578128744584&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40hapi%2Ftopo%2Fdownload%2F%40hapi%2Ftopo-3.1.6.tgz",
+      "resolved": "https://registry.npm.taobao.org/@hapi/topo/download/@hapi/topo-3.1.6.tgz",
       "integrity": "sha1-aNk1+j6uf91asNf5U/MgXYsr/Ck=",
       "dev": true,
       "requires": {
@@ -3967,7 +3967,7 @@
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&sync_timestamp=1573557674483&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
@@ -4939,7 +4939,7 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&sync_timestamp=1573557674483&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
@@ -8177,7 +8177,7 @@
     },
     "eslint-plugin-vue": {
       "version": "5.2.3",
-      "resolved": "https://registry.npm.taobao.org/eslint-plugin-vue/download/eslint-plugin-vue-5.2.3.tgz?cache=0&sync_timestamp=1577727074484&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-plugin-vue%2Fdownload%2Feslint-plugin-vue-5.2.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/eslint-plugin-vue/download/eslint-plugin-vue-5.2.3.tgz?cache=0&sync_timestamp=1577438946533&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-plugin-vue%2Fdownload%2Feslint-plugin-vue-5.2.3.tgz",
       "integrity": "sha1-PudZfYI7VHiASy/rqYY7G3QnOWE=",
       "dev": true,
       "requires": {
@@ -17677,7 +17677,7 @@
     },
     "vue": {
       "version": "2.6.11",
-      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.11.tgz",
+      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.11.tgz?cache=0&sync_timestamp=1576868474341&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue%2Fdownload%2Fvue-2.6.11.tgz",
       "integrity": "sha1-dllNh31LEiNEBuhONSdcbVFBJcU="
     },
     "vue-cli-plugin-vuetify": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,20 +33,23 @@
 
   export default {
     name: "App",
-    data: () => ({
-      drawer: true
-    }),
+    data() {
+      return {
+        drawer: true
+      }
+    },
     components: {
       LoginHeader,
       SideNav
     },
     methods: {
       toggle() {
-      this.drawer = !this.drawer;
+        this.drawer = !this.drawer;
+      }
     }
-  }
-};
+  };
 </script>
+
 <style>
   .gold {
     background-color: #fec84e;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,29 +28,44 @@
 </template>
 
 <script>
-import LoginHeader from "./components/header/LoginHeader";
-import SideNav from "./components/side/SideNav";
+  import LoginHeader from "./components/header/LoginHeader";
+  import SideNav from "./components/side/SideNav";
 
-export default {
-  name: "App",
-  data: () => ({
-    drawer: true
-  }),
-  components: {
-    LoginHeader,
-    SideNav
-  },
-  methods: {
-    toggle() {
+  export default {
+    name: "App",
+    data: () => ({
+      drawer: true
+    }),
+    components: {
+      LoginHeader,
+      SideNav
+    },
+    methods: {
+      toggle() {
       this.drawer = !this.drawer;
     }
   }
 };
 </script>
 <style>
-@media all and (min-width: 1025px) {
-  .side-nav-toggle-btn {
-    display: none;
+  .gold {
+    background-color: #fec84e;
+    background-image: linear-gradient(315deg, #fec84e 0%, #ffdea8 74%);
   }
-}
+
+  .silver {
+    background-color: #f1f2f6;
+    background-image: linear-gradient(315deg, #f1f2f6 0%, #c9c6c6 74%);
+  }
+
+  .bronze {
+    background-color: #f5d3c8;
+    background-image: linear-gradient(315deg, #f5d3c8 0%, #c08552 74%);
+  }
+
+  @media all and (min-width: 1025px) {
+    .side-nav-toggle-btn {
+      display: none;
+    }
+  }
 </style>

--- a/frontend/src/components/Index.vue
+++ b/frontend/src/components/Index.vue
@@ -5,9 +5,8 @@
         <SearchBox/>
         <v-window
                 v-model="window"
-                class="elevation-1"
+                class="elevation-1 main-card-content"
                 vertical
-                style="height: 500px; max-height: 500px; overflow: scroll; background-color: white"
         >
           <v-window-item
                   v-for="indexContent in indexContents"
@@ -63,8 +62,17 @@
       indexContents: [
         {id: 1, button: NoticeButton, content: Notice},
         {id: 2, button: KeywordRankButton, content: KeywordRank}
-    ],
-    window: 0
-  })
-};
+      ],
+      window: 0
+    })
+  };
 </script>
+
+<style scoped>
+  .main-card-content {
+    height: 500px;
+    max-height: 500px;
+    overflow: scroll;
+    background-color: white;
+  }
+</style>

--- a/frontend/src/components/Index.vue
+++ b/frontend/src/components/Index.vue
@@ -2,77 +2,77 @@
   <div style="margin-left: 40px; margin-top: 50px">
     <v-row>
       <v-col sm="7">
-        <SearchBox/>
+        <SearchBox />
         <v-window
-                v-model="window"
-                class="elevation-1 main-card-content"
-                vertical
+          v-model="window"
+          class="elevation-1 main-card-content"
+          vertical
         >
           <v-window-item
-                  v-for="indexContent in indexContents"
-                  :key="indexContent.id"
+            v-for="indexContent in indexContents"
+            :key="indexContent.id"
           >
-            <div v-bind:is="indexContent.content"/>
+            <div v-bind:is="indexContent.content" />
           </v-window-item>
         </v-window>
 
         <v-bottom-navigation
-                dark
-                shift
-                background-color="#214b7d"
-                v-model="window"
+          dark
+          shift
+          background-color="#214b7d"
+          v-model="window"
         >
           <v-item
-                  v-for="indexContent in indexContents"
-                  :key="indexContent.id"
-                  v-slot:default="{ active, toggle }"
+            v-for="indexContent in indexContents"
+            :key="indexContent.id"
+            v-slot:default="{ active, toggle }"
           >
             <div
-                    v-bind:is="indexContent.button"
-                    :input-value="active"
-                    @click="toggle"
+              v-bind:is="indexContent.button"
+              :input-value="active"
+              @click="toggle"
             />
           </v-item>
         </v-bottom-navigation>
       </v-col>
 
-      <BirthdayList style="padding-top: 70px"/>
+      <BirthdayList style="padding-top: 70px" />
     </v-row>
-<!--    <GithubRank></GithubRank>-->
+    <!--    <GithubRank></GithubRank>-->
   </div>
 </template>
 
 <script>
-  import BirthdayList from "./home/BirthdayList";
-  import Notice from "./home/Notice";
-  import KeywordRank from "./home/KeywordRank";
-  import KeywordRankButton from "./home/KeywordRankButton";
-  import NoticeButton from "./home/NoticeButton";
-  import SearchBox from "./home/SearchBox";
-  import GithubRank from "./home/GithubRank";
+import BirthdayList from "./home/BirthdayList";
+import Notice from "./home/Notice";
+import KeywordRank from "./home/KeywordRank";
+import KeywordRankButton from "./home/KeywordRankButton";
+import NoticeButton from "./home/NoticeButton";
+import SearchBox from "./home/SearchBox";
+import GithubRank from "./home/GithubRank";
 
-  export default {
-    name: "Index",
-    components: {
-      GithubRank,
-      BirthdayList,
-      SearchBox
-    },
-    data: () => ({
-      indexContents: [
-        {id: 1, button: NoticeButton, content: Notice},
-        {id: 2, button: KeywordRankButton, content: KeywordRank}
-      ],
-      window: 0
-    })
-  };
+export default {
+  name: "Index",
+  components: {
+    GithubRank,
+    BirthdayList,
+    SearchBox
+  },
+  data: () => ({
+    indexContents: [
+      { id: 1, button: NoticeButton, content: Notice },
+      { id: 2, button: KeywordRankButton, content: KeywordRank }
+    ],
+    window: 0
+  })
+};
 </script>
 
 <style scoped>
-  .main-card-content {
-    height: 500px;
-    max-height: 500px;
-    overflow: scroll;
-    background-color: white;
-  }
+.main-card-content {
+  height: 500px;
+  max-height: 500px;
+  overflow: scroll;
+  background-color: white;
+}
 </style>

--- a/frontend/src/components/Index.vue
+++ b/frontend/src/components/Index.vue
@@ -1,62 +1,68 @@
 <template>
-  <v-row style="margin-left: 40px; margin-top: 50px">
-    <v-col sm="7">
-      <SearchBox />
-      <v-window
-        v-model="window"
-        class="elevation-1"
-        vertical
-        style="height: 500px; max-height: 500px; overflow: scroll; background-color: white"
-      >
-        <v-window-item
-          v-for="indexContent in indexContents"
-          :key="indexContent.id"
+  <div style="margin-left: 40px; margin-top: 50px">
+    <v-row>
+      <v-col sm="7">
+        <SearchBox/>
+        <v-window
+                v-model="window"
+                class="elevation-1"
+                vertical
+                style="height: 500px; max-height: 500px; overflow: scroll; background-color: white"
         >
-          <div v-bind:is="indexContent.content" />
-        </v-window-item>
-      </v-window>
+          <v-window-item
+                  v-for="indexContent in indexContents"
+                  :key="indexContent.id"
+          >
+            <div v-bind:is="indexContent.content"/>
+          </v-window-item>
+        </v-window>
 
-      <v-bottom-navigation
-        dark
-        shift
-        background-color="#214b7d"
-        v-model="window"
-      >
-        <v-item
-          v-for="indexContent in indexContents"
-          :key="indexContent.id"
-          v-slot:default="{ active, toggle }"
+        <v-bottom-navigation
+                dark
+                shift
+                background-color="#214b7d"
+                v-model="window"
         >
-          <div
-            v-bind:is="indexContent.button"
-            :input-value="active"
-            @click="toggle"
-          />
-        </v-item>
-      </v-bottom-navigation>
-    </v-col>
+          <v-item
+                  v-for="indexContent in indexContents"
+                  :key="indexContent.id"
+                  v-slot:default="{ active, toggle }"
+          >
+            <div
+                    v-bind:is="indexContent.button"
+                    :input-value="active"
+                    @click="toggle"
+            />
+          </v-item>
+        </v-bottom-navigation>
+      </v-col>
 
-    <BirthdayList style="padding-top: 70px" />
-  </v-row>
+      <BirthdayList style="padding-top: 70px"/>
+    </v-row>
+    <GithubRank></GithubRank>
+  </div>
 </template>
 
 <script>
-import BirthdayList from "./home/BirthdayList";
-import Notice from "./home/Notice";
-import KeywordRank from "./home/KeywordRank";
-import KeywordRankButton from "./home/KeywordRankButton";
-import NoticeButton from "./home/NoticeButton";
-import SearchBox from "./home/SearchBox";
-export default {
-  name: "Index",
-  components: {
-    BirthdayList,
-    SearchBox
-  },
-  data: () => ({
-    indexContents: [
-      { id: 1, button: NoticeButton, content: Notice },
-      { id: 2, button: KeywordRankButton, content: KeywordRank }
+  import BirthdayList from "./home/BirthdayList";
+  import Notice from "./home/Notice";
+  import KeywordRank from "./home/KeywordRank";
+  import KeywordRankButton from "./home/KeywordRankButton";
+  import NoticeButton from "./home/NoticeButton";
+  import SearchBox from "./home/SearchBox";
+  import GithubRank from "./home/GithubRank";
+
+  export default {
+    name: "Index",
+    components: {
+      GithubRank,
+      BirthdayList,
+      SearchBox
+    },
+    data: () => ({
+      indexContents: [
+        {id: 1, button: NoticeButton, content: Notice},
+        {id: 2, button: KeywordRankButton, content: KeywordRank}
     ],
     window: 0
   })

--- a/frontend/src/components/Index.vue
+++ b/frontend/src/components/Index.vue
@@ -39,7 +39,7 @@
 
       <BirthdayList style="padding-top: 70px"/>
     </v-row>
-    <GithubRank></GithubRank>
+<!--    <GithubRank></GithubRank>-->
   </div>
 </template>
 

--- a/frontend/src/components/Index.vue
+++ b/frontend/src/components/Index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="margin-left: 40px; margin-top: 50px">
+  <v-container style="margin-left: 40px; margin-top: 30px">
     <v-row>
       <v-col sm="7">
         <SearchBox />
@@ -12,7 +12,7 @@
             v-for="indexContent in indexContents"
             :key="indexContent.id"
           >
-            <div v-bind:is="indexContent.content" />
+            <v-content :is="indexContent.content" />
           </v-window-item>
         </v-window>
 
@@ -27,8 +27,8 @@
             :key="indexContent.id"
             v-slot:default="{ active, toggle }"
           >
-            <div
-              v-bind:is="indexContent.button"
+            <v-content
+              :is="indexContent.button"
               :input-value="active"
               @click="toggle"
             />
@@ -39,7 +39,7 @@
       <BirthdayList style="padding-top: 70px" />
     </v-row>
     <!--    <GithubRank></GithubRank>-->
-  </div>
+  </v-container>
 </template>
 
 <script>

--- a/frontend/src/components/home/GithubRank.vue
+++ b/frontend/src/components/home/GithubRank.vue
@@ -1,19 +1,19 @@
 <template>
     <v-row>
         <v-col sm="7">
-            <GithubRankDetail></GithubRankDetail>
-            <AllRank></AllRank>
+            <MyCommitRank></MyCommitRank>
+            <AllCommitRank></AllCommitRank>
         </v-col>
     </v-row>
 </template>
 
 <script>
-    import AllRank from "./githubRank/AllRank";
-    import GithubRankDetail from "./githubRank/GithubRankDetail";
+    import AllCommitRank from "./githubRank/AllCommitRank";
+    import MyCommitRank from "./githubRank/MyCommitRank";
 
     export default {
         name: "GithubRank",
-        components: {GithubRankDetail, AllRank}
+        components: {MyCommitRank, AllCommitRank}
     }
 </script>
 

--- a/frontend/src/components/home/GithubRank.vue
+++ b/frontend/src/components/home/GithubRank.vue
@@ -1,30 +1,28 @@
 <template>
-    <v-row>
-        <v-col sm="7">
-            <MyCommitRank v-if="isCrew"></MyCommitRank>
-            <AllCommitRank></AllCommitRank>
-        </v-col>
-    </v-row>
+  <v-row>
+    <v-col sm="7">
+      <MyCommitRank v-if="isCrew"></MyCommitRank>
+      <AllCommitRank></AllCommitRank>
+    </v-col>
+  </v-row>
 </template>
 
 <script>
-    import AllCommitRank from "./githubRank/AllCommitRank";
-    import MyCommitRank from "./githubRank/MyCommitRank";
+import AllCommitRank from "./githubRank/AllCommitRank";
+import MyCommitRank from "./githubRank/MyCommitRank";
 
-    export default {
-        name: "GithubRank",
-        components: {MyCommitRank, AllCommitRank},
-        computed: {
-            isCrew() {
-                if (this.$store.state.userContext === null) {
-                    return false;
-                }
-                return this.$store.state.userContext.role !== "ROLE_PRECOURSE";
-            }
-        },
+export default {
+  name: "GithubRank",
+  components: { MyCommitRank, AllCommitRank },
+  computed: {
+    isCrew() {
+      if (this.$store.state.userContext === null) {
+        return false;
+      }
+      return this.$store.state.userContext.role !== "ROLE_PRECOURSE";
     }
+  }
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/frontend/src/components/home/GithubRank.vue
+++ b/frontend/src/components/home/GithubRank.vue
@@ -1,7 +1,7 @@
 <template>
     <v-row>
         <v-col sm="7">
-            <MyCommitRank></MyCommitRank>
+            <MyCommitRank v-if="isCrew"></MyCommitRank>
             <AllCommitRank></AllCommitRank>
         </v-col>
     </v-row>
@@ -13,7 +13,15 @@
 
     export default {
         name: "GithubRank",
-        components: {MyCommitRank, AllCommitRank}
+        components: {MyCommitRank, AllCommitRank},
+        computed: {
+            isCrew() {
+                if (this.$store.state.userContext === null) {
+                    return false;
+                }
+                return this.$store.state.userContext.role !== "ROLE_PRECOURSE";
+            }
+        },
     }
 </script>
 

--- a/frontend/src/components/home/GithubRank.vue
+++ b/frontend/src/components/home/GithubRank.vue
@@ -1,10 +1,12 @@
 <template>
-  <v-row>
-    <v-col sm="7">
-      <MyCommitRank v-if="isCrew"></MyCommitRank>
-      <AllCommitRank></AllCommitRank>
-    </v-col>
-  </v-row>
+  <v-layout>
+    <v-row>
+      <v-col sm="7">
+        <MyCommitRank v-if="isCrew"></MyCommitRank>
+        <AllCommitRank></AllCommitRank>
+      </v-col>
+    </v-row>
+  </v-layout>
 </template>
 
 <script>
@@ -16,7 +18,7 @@ export default {
   components: { MyCommitRank, AllCommitRank },
   computed: {
     isCrew() {
-      if (this.$store.state.userContext === null) {
+      if (!this.$store.state.userContext) {
         return false;
       }
       return this.$store.state.userContext.role !== "ROLE_PRECOURSE";

--- a/frontend/src/components/home/GithubRank.vue
+++ b/frontend/src/components/home/GithubRank.vue
@@ -1,0 +1,22 @@
+<template>
+    <v-row>
+        <v-col sm="7">
+            <GithubRankDetail></GithubRankDetail>
+            <AllRank></AllRank>
+        </v-col>
+    </v-row>
+</template>
+
+<script>
+    import AllRank from "./githubRank/AllRank";
+    import GithubRankDetail from "./githubRank/GithubRankDetail";
+
+    export default {
+        name: "GithubRank",
+        components: {GithubRankDetail, AllRank}
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -38,7 +38,7 @@
 
 <script>
     export default {
-        name: "AllRank",
+        name: "AllCommitRank",
         data() {
             return {
                 users: [

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -1,112 +1,108 @@
 <template>
-    <v-card height="1000px">
-        <v-card-title style="color: #1d1d1f">
-            Top 50
-        </v-card-title>
-        <v-list-item-group>
-            <v-list-item
-                    v-for="(user, rank) in users"
-                    :key="user.githubId"
-                    class="rank"
-                    :href="`https://github.com/${user.githubId}`"
-                    target="_blank"
-            >
-                <v-list-item-avatar
-                        size="62"
-                        class="badge"
-                        :class="setBadgeColor(rank + 1)"
-                >
-                    {{ rank + 1 }}위
-                </v-list-item-avatar>
-                <v-list-item-content style="font-size: 1.1rem">
-                    <div class="github-id">
-                        {{ user.githubId }}
-                    </div>
-                    <div style="margin-top: 3px;">
-                        <span>{{ user.degree }}기 </span>
-                        <span>{{ user.nickname}}</span>
-                    </div>
-                </v-list-item-content>
-                <span style="font-size: 0.9rem">
-                    {{ numberWithCommas(user.point) }} Point
-                </span>
-            </v-list-item>
-        </v-list-item-group>
-    </v-card>
+  <v-card height="1000px">
+    <v-card-title style="color: #1d1d1f">
+      Top 50
+    </v-card-title>
+    <v-list-item-group>
+      <v-list-item
+        v-for="(user, rank) in users"
+        :key="user.githubId"
+        class="rank"
+        :href="`https://github.com/${user.githubId}`"
+        target="_blank"
+      >
+        <v-list-item-avatar
+          size="62"
+          class="badge"
+          :class="setBadgeColor(rank + 1)"
+        >
+          {{ rank + 1 }}위
+        </v-list-item-avatar>
+        <v-list-item-content style="font-size: 1.1rem">
+          <div class="github-id">
+            {{ user.githubId }}
+          </div>
+          <div style="margin-top: 3px;">
+            <span>{{ user.degree }}기 </span>
+            <span>{{ user.nickname }}</span>
+          </div>
+        </v-list-item-content>
+        <span style="font-size: 0.9rem">
+          {{ numberWithCommas(user.point) }} Point
+        </span>
+      </v-list-item>
+    </v-list-item-group>
+  </v-card>
 </template>
 
 <script>
-    export default {
-        name: "AllCommitRank",
-        data() {
-            return {
-                users: [
-                    {
-                        degree: 1,
-                        githubId: "hyojaekim",
-                        nickname: "효오",
-                        point: 3000,
-                    },
-                    {
-                        degree: 1,
-                        githubId: "hyojaekim",
-                        nickname: "효오",
-                        point: 3000,
-                    },
-                    {
-                        degree: 1,
-                        githubId: "hyojaekim",
-                        nickname: "효오",
-                        point: 3000,
-                    },
-                    {
-                        degree: 1,
-                        githubId: "hyojaekim",
-                        nickname: "효오",
-                        point: 3000,
-                    },
-                ],
-                badgeColor: {
-                    1: "gold",
-                    2: "silver",
-                    3: "bronze",
-                },
-            }
+export default {
+  name: "AllCommitRank",
+  data() {
+    return {
+      users: [
+        {
+          degree: 1,
+          githubId: "hyojaekim",
+          nickname: "효오",
+          point: 3000
         },
-        methods: {
-            setBadgeColor(rank) {
-                let badgeColor = this.badgeColor[rank];
-                return badgeColor ? badgeColor : "default";
-            },
-            numberWithCommas(point) {
-                return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
-            }
+        {
+          degree: 1,
+          githubId: "hyojaekim",
+          nickname: "효오",
+          point: 3000
+        },
+        {
+          degree: 1,
+          githubId: "hyojaekim",
+          nickname: "효오",
+          point: 3000
+        },
+        {
+          degree: 1,
+          githubId: "hyojaekim",
+          nickname: "효오",
+          point: 3000
         }
+      ],
+      badgeColor: {
+        1: "gold",
+        2: "silver",
+        3: "bronze"
+      }
+    };
+  },
+  methods: {
+    setBadgeColor(rank) {
+      let badgeColor = this.badgeColor[rank];
+      return badgeColor ? badgeColor : "default";
+    },
+    numberWithCommas(point) {
+      return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
     }
+  }
+};
 </script>
 
 <style scoped>
-    .rank {
-        height: 100px;
-        font-weight: bold;
-        transition: 0.3s;
-    }
-
-    .rank:hover {
-        box-shadow: 2px 3px 8px 3px rgba(0, 0, 0, 0.2);
-    }
-
-    .badge {
-        box-shadow: 1px 1px 4px gray inset;
-    }
-
-    .github-id {
-        font-weight: normal;
-        font-size: 0.8rem;
-    }
-
-    .default {
-        background: rgb(250, 250, 250);
-        color: #424242;
-    }
+.rank {
+  height: 100px;
+  font-weight: bold;
+  transition: 0.3s;
+}
+.rank:hover {
+  box-shadow: 2px 3px 8px 3px rgba(0, 0, 0, 0.2);
+}
+.badge {
+  box-shadow: 1px 1px 4px gray inset;
+}
+.github-id {
+  font-weight: normal;
+  font-size: 0.8rem;
+}
+.default {
+  background: rgb(250, 250, 250);
+  color: #424242;
+}
 </style>

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -16,7 +16,7 @@
           class="badge"
           :class="setBadgeColor(rank + 1)"
         >
-          {{ rank + 1 }}위
+          <span>{{ rank + 1 }}위</span>
         </v-list-item-avatar>
         <v-list-item-content style="font-size: 1.1rem">
           <div class="github-id">

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -14,7 +14,7 @@
             >
                 <v-list-item-avatar
                         size="62"
-                        :class="setRankColor(rank)"
+                        :class="setBadgeColor(rank + 1)"
                         style="box-shadow: 1px 1px 4px gray inset"
                 >
                     {{ rank + 1 }}위
@@ -67,19 +67,17 @@
                         point: 3000,
                     },
                 ],
+                badgeColor: {
+                    1: "gold",
+                    2: "silver",
+                    3: "bronze",
+                },
             }
         },
         methods: {
-            setRankColor(rank) {
-                if (rank > 2) return "default"
-                switch (rank) {
-                    case 0:
-                        return "gold"
-                    case 1:
-                        return "silver"
-                    case 2:
-                        return "bronze"
-                }
+            setBadgeColor(rank) {
+                let badgeColor = this.badgeColor[rank];
+                return badgeColor ? badgeColor : "default";
             },
             numberWithCommas(point) {
                 return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -9,7 +9,7 @@
                     :key="user.githubId"
                     class="rank-hover"
                     style="height: 100px; font-weight: bold"
-                    :href="'https://github.com/' + user.githubId"
+                    :href="`https://github.com/${user.githubId}`"
                     target="_blank"
             >
                 <v-list-item-avatar

--- a/frontend/src/components/home/githubRank/AllCommitRank.vue
+++ b/frontend/src/components/home/githubRank/AllCommitRank.vue
@@ -7,20 +7,19 @@
             <v-list-item
                     v-for="(user, rank) in users"
                     :key="user.githubId"
-                    class="rank-hover"
-                    style="height: 100px; font-weight: bold"
+                    class="rank"
                     :href="`https://github.com/${user.githubId}`"
                     target="_blank"
             >
                 <v-list-item-avatar
                         size="62"
+                        class="badge"
                         :class="setBadgeColor(rank + 1)"
-                        style="box-shadow: 1px 1px 4px gray inset"
                 >
                     {{ rank + 1 }}위
                 </v-list-item-avatar>
                 <v-list-item-content style="font-size: 1.1rem">
-                    <div style="font-weight: normal; font-size: 0.8rem">
+                    <div class="github-id">
                         {{ user.githubId }}
                     </div>
                     <div style="margin-top: 3px;">
@@ -87,12 +86,23 @@
 </script>
 
 <style scoped>
-    .rank-hover {
+    .rank {
+        height: 100px;
+        font-weight: bold;
         transition: 0.3s;
     }
 
-    .rank-hover:hover {
+    .rank:hover {
         box-shadow: 2px 3px 8px 3px rgba(0, 0, 0, 0.2);
+    }
+
+    .badge {
+        box-shadow: 1px 1px 4px gray inset;
+    }
+
+    .github-id {
+        font-weight: normal;
+        font-size: 0.8rem;
     }
 
     .default {

--- a/frontend/src/components/home/githubRank/AllRank.vue
+++ b/frontend/src/components/home/githubRank/AllRank.vue
@@ -29,7 +29,7 @@
                     </div>
                 </v-list-item-content>
                 <span style="font-size: 0.9rem">
-                    {{ user.point }} Point
+                    {{ numberWithCommas(user.point) }} Point
                 </span>
             </v-list-item>
         </v-list-item-group>
@@ -80,6 +80,9 @@
                     case 2:
                         return "bronze"
                 }
+            },
+            numberWithCommas(point) {
+                return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
             }
         }
     }

--- a/frontend/src/components/home/githubRank/AllRank.vue
+++ b/frontend/src/components/home/githubRank/AllRank.vue
@@ -1,0 +1,17 @@
+<template>
+    <v-card height="1000px">
+        <v-card-title style="color: #1d1d1f">
+            Top 50
+        </v-card-title>
+    </v-card>
+</template>
+
+<script>
+    export default {
+        name: "AllRank"
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/home/githubRank/AllRank.vue
+++ b/frontend/src/components/home/githubRank/AllRank.vue
@@ -3,15 +3,99 @@
         <v-card-title style="color: #1d1d1f">
             Top 50
         </v-card-title>
+        <v-list-item-group>
+            <v-list-item
+                    v-for="(user, rank) in users"
+                    :key="user.githubId"
+                    class="rank-hover"
+                    style="height: 100px; font-weight: bold"
+                    :href="'https://github.com/' + user.githubId"
+                    target="_blank"
+            >
+                <v-list-item-avatar
+                        size="62"
+                        :class="setRankColor(rank)"
+                        style="box-shadow: 1px 1px 4px gray inset"
+                >
+                    {{ rank + 1 }}위
+                </v-list-item-avatar>
+                <v-list-item-content style="font-size: 1.1rem">
+                    <div style="font-weight: normal; font-size: 0.8rem">
+                        {{ user.githubId }}
+                    </div>
+                    <div style="margin-top: 3px;">
+                        <span>{{ user.degree }}기 </span>
+                        <span>{{ user.nickname}}</span>
+                    </div>
+                </v-list-item-content>
+                <span style="font-size: 0.9rem">
+                    {{ user.point }} Point
+                </span>
+            </v-list-item>
+        </v-list-item-group>
     </v-card>
 </template>
 
 <script>
     export default {
-        name: "AllRank"
+        name: "AllRank",
+        data() {
+            return {
+                users: [
+                    {
+                        degree: 1,
+                        githubId: "hyojaekim",
+                        nickname: "효오",
+                        point: 3000,
+                    },
+                    {
+                        degree: 1,
+                        githubId: "hyojaekim",
+                        nickname: "효오",
+                        point: 3000,
+                    },
+                    {
+                        degree: 1,
+                        githubId: "hyojaekim",
+                        nickname: "효오",
+                        point: 3000,
+                    },
+                    {
+                        degree: 1,
+                        githubId: "hyojaekim",
+                        nickname: "효오",
+                        point: 3000,
+                    },
+                ],
+            }
+        },
+        methods: {
+            setRankColor(rank) {
+                if (rank > 2) return "default"
+                switch (rank) {
+                    case 0:
+                        return "gold"
+                    case 1:
+                        return "silver"
+                    case 2:
+                        return "bronze"
+                }
+            }
+        }
     }
 </script>
 
 <style scoped>
+    .rank-hover {
+        transition: 0.3s;
+    }
 
+    .rank-hover:hover {
+        box-shadow: 2px 3px 8px 3px rgba(0, 0, 0, 0.2);
+    }
+
+    .default {
+        background: rgb(250, 250, 250);
+        color: #424242;
+    }
 </style>

--- a/frontend/src/components/home/githubRank/GithubRankDetail.vue
+++ b/frontend/src/components/home/githubRank/GithubRankDetail.vue
@@ -3,8 +3,10 @@
             dark
             color="rgba(66,66,66)"
             height="100px"
-            class="d-flex align-center mb-6"
+            class="d-flex align-center mb-6 rank-hover"
             style="font-weight: bold"
+            :href="'https://github.com/' + githubId"
+            target="_blank"
     >
         <v-list-item>
             <v-list-item-avatar
@@ -51,5 +53,11 @@
 </script>
 
 <style scoped>
+    .rank-hover {
+        transition: 0.3s;
+    }
 
+    .rank-hover:hover {
+        box-shadow: 3px 5px 9px 6px rgba(0, 0, 0, 0.2);
+    }
 </style>

--- a/frontend/src/components/home/githubRank/GithubRankDetail.vue
+++ b/frontend/src/components/home/githubRank/GithubRankDetail.vue
@@ -20,7 +20,7 @@
                 <div style="font-weight: normal; font-size: 0.8rem">
                     {{ githubId }}
                 </div>
-                <div>
+                <div style="margin-top: 3px">
                     <span>{{ degree }}기 </span>
                     <span>{{ nickname }}</span>
                 </div>
@@ -58,6 +58,7 @@
     }
 
     .rank-hover:hover {
-        box-shadow: 3px 5px 9px 6px rgba(0, 0, 0, 0.2);
+        box-shadow: 1px 3px 7px 4px rgba(0, 0, 0, 0.2);
+        background-color: rgba(66, 66, 66, 0.9) !important;
     }
 </style>

--- a/frontend/src/components/home/githubRank/GithubRankDetail.vue
+++ b/frontend/src/components/home/githubRank/GithubRankDetail.vue
@@ -1,0 +1,55 @@
+<template>
+    <v-card
+            dark
+            color="rgba(66,66,66)"
+            height="100px"
+            class="d-flex align-center mb-6"
+            style="font-weight: bold"
+    >
+        <v-list-item>
+            <v-list-item-avatar
+                    size="62"
+                    color="rgb(250,250,250)"
+                    style="color: #424242; box-shadow: 1px 1px 4px gray inset"
+            >
+                {{ rank }}위
+            </v-list-item-avatar>
+            <v-list-item-content style="font-size: 1.3rem">
+                <div style="font-weight: normal; font-size: 0.8rem">
+                    {{ githubId }}
+                </div>
+                <div>
+                    <span>{{ degree }}기 </span>
+                    <span>{{ nickname }}</span>
+                </div>
+            </v-list-item-content>
+            <span>
+                {{ numberWithCommas(point) }} Point
+            </span>
+        </v-list-item>
+    </v-card>
+</template>
+
+<script>
+    export default {
+        name: "GithubRankDetail",
+        data() {
+            return {
+                rank: 1,
+                degree: 1,
+                nickname: "효오",
+                githubId: "hyojaekim",
+                point: 31232,
+            }
+        },
+        methods: {
+            numberWithCommas(point) {
+                return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+            }
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -5,7 +5,7 @@
             height="100px"
             class="d-flex align-center mb-6 rank-hover"
             style="font-weight: bold"
-            :href="'https://github.com/' + user.githubId"
+            :href="`https://github.com/${user.githubId}`"
             target="_blank"
     >
         <v-list-item>
@@ -64,7 +64,7 @@
         },
         created() {
             axios
-                .get(this.$store.state.requestUrl + "/api/github/commit/rank/me", {
+                .get(`${this.$store.state.requestUrl}/api/github/commit/rank/me`, {
                     withCredentials: true
                 })
                 .then(res => {

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -57,18 +57,27 @@ export default {
     },
     numberWithCommas(point) {
       return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+    },
+    async setMyCommitRank() {
+      const user = await this.fetchMyCommitRank();
+      if (!user) {
+        this.user = user;
+      }
+    },
+    fetchMyCommitRank() {
+      axios
+        .get(`${this.$store.state.requestUrl}/api/github/commit/rank/me`, {
+          withCredentials: true
+        })
+        .then(res => {
+          if (res.status === 200) {
+            return res.data;
+          }
+        });
     }
   },
   created() {
-    axios
-      .get(`${this.$store.state.requestUrl}/api/github/commit/rank/me`, {
-        withCredentials: true
-      })
-      .then(res => {
-        if (res.status === 200) {
-          this.user = res.data;
-        }
-      });
+    this.setMyCommitRank();
   }
 };
 </script>

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -34,7 +34,7 @@
 
 <script>
     export default {
-        name: "GithubRankDetail",
+        name: "MyCommitRank",
         data() {
             return {
                 rank: 1,

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -3,21 +3,20 @@
             dark
             color="rgba(66,66,66)"
             height="100px"
-            class="d-flex align-center mb-6 rank-hover"
-            style="font-weight: bold"
+            class="d-flex align-center mb-6 rank"
             :href="`https://github.com/${user.githubId}`"
             target="_blank"
     >
         <v-list-item>
             <v-list-item-avatar
                     size="62"
+                    class="badge"
                     :class="setBadgeColor(user.rank)"
-                    style="color: #424242; box-shadow: 1px 1px 4px gray inset"
             >
                 {{ user.rank }}위
             </v-list-item-avatar>
             <v-list-item-content style="font-size: 1.3rem">
-                <div style="font-weight: normal; font-size: 0.8rem">
+                <div class="github-id">
                     {{ user.githubId }}
                 </div>
                 <div style="margin-top: 3px">
@@ -77,13 +76,24 @@
 </script>
 
 <style scoped>
-    .rank-hover {
+    .rank {
+        font-weight: bold;
         transition: 0.3s;
     }
 
-    .rank-hover:hover {
+    .rank:hover {
         box-shadow: 1px 3px 7px 4px rgba(0, 0, 0, 0.2);
         background-color: rgba(66, 66, 66, 0.9) !important;
+    }
+
+    .badge {
+        color: #424242;
+        box-shadow: 1px 1px 4px gray inset;
+    }
+
+    .github-id {
+        font-weight: normal;
+        font-size: 0.8rem;
     }
 
     .default {

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -5,43 +5,47 @@
             height="100px"
             class="d-flex align-center mb-6 rank-hover"
             style="font-weight: bold"
-            :href="'https://github.com/' + githubId"
+            :href="'https://github.com/' + user.githubId"
             target="_blank"
     >
         <v-list-item>
             <v-list-item-avatar
                     size="62"
-                    :class="setBadgeColor(rank)"
+                    :class="setBadgeColor(user.rank)"
                     style="color: #424242; box-shadow: 1px 1px 4px gray inset"
             >
-                {{ rank }}위
+                {{ user.rank }}위
             </v-list-item-avatar>
             <v-list-item-content style="font-size: 1.3rem">
                 <div style="font-weight: normal; font-size: 0.8rem">
-                    {{ githubId }}
+                    {{ user.githubId }}
                 </div>
                 <div style="margin-top: 3px">
-                    <span>{{ degree }}기 </span>
-                    <span>{{ nickname }}</span>
+                    <span>{{ user.degree }}기 </span>
+                    <span>{{ user.nickname }}</span>
                 </div>
             </v-list-item-content>
             <span>
-                {{ numberWithCommas(point) }} Point
+                {{ numberWithCommas(user.point) }} Point
             </span>
         </v-list-item>
     </v-card>
 </template>
 
 <script>
+    import axios from "axios";
+
     export default {
         name: "MyCommitRank",
         data() {
             return {
-                rank: 1,
-                degree: 1,
-                nickname: "효오",
-                githubId: "hyojaekim",
-                point: 31232,
+                user: {
+                    rank: "",
+                    degree: "",
+                    nickname: "",
+                    githubId: "",
+                    point: "",
+                },
                 badgeColor: {
                     1: "gold",
                     2: "silver",
@@ -57,6 +61,17 @@
             numberWithCommas(point) {
                 return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
             }
+        },
+        created() {
+            axios
+                .get(this.$store.state.requestUrl + "/api/github/commit/rank/me", {
+                    withCredentials: true
+                })
+                .then(res => {
+                    if (res.status === 200) {
+                        this.user = res.data
+                    }
+                });
         }
     }
 </script>

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -11,7 +11,7 @@
         <v-list-item>
             <v-list-item-avatar
                     size="62"
-                    color="rgb(250,250,250)"
+                    :class="setBadgeColor(rank)"
                     style="color: #424242; box-shadow: 1px 1px 4px gray inset"
             >
                 {{ rank }}위
@@ -42,9 +42,18 @@
                 nickname: "효오",
                 githubId: "hyojaekim",
                 point: 31232,
+                badgeColor: {
+                    1: "gold",
+                    2: "silver",
+                    3: "bronze",
+                }
             }
         },
         methods: {
+            setBadgeColor(rank) {
+                let badgeColor = this.badgeColor[rank];
+                return badgeColor ? badgeColor : "default";
+            },
             numberWithCommas(point) {
                 return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
             }
@@ -60,5 +69,9 @@
     .rank-hover:hover {
         box-shadow: 1px 3px 7px 4px rgba(0, 0, 0, 0.2);
         background-color: rgba(66, 66, 66, 0.9) !important;
+    }
+
+    .default {
+        background: rgb(250, 250, 250);
     }
 </style>

--- a/frontend/src/components/home/githubRank/MyCommitRank.vue
+++ b/frontend/src/components/home/githubRank/MyCommitRank.vue
@@ -1,102 +1,96 @@
 <template>
-    <v-card
-            dark
-            color="rgba(66,66,66)"
-            height="100px"
-            class="d-flex align-center mb-6 rank"
-            :href="`https://github.com/${user.githubId}`"
-            target="_blank"
-    >
-        <v-list-item>
-            <v-list-item-avatar
-                    size="62"
-                    class="badge"
-                    :class="setBadgeColor(user.rank)"
-            >
-                {{ user.rank }}위
-            </v-list-item-avatar>
-            <v-list-item-content style="font-size: 1.3rem">
-                <div class="github-id">
-                    {{ user.githubId }}
-                </div>
-                <div style="margin-top: 3px">
-                    <span>{{ user.degree }}기 </span>
-                    <span>{{ user.nickname }}</span>
-                </div>
-            </v-list-item-content>
-            <span>
-                {{ numberWithCommas(user.point) }} Point
-            </span>
-        </v-list-item>
-    </v-card>
+  <v-card
+    dark
+    color="rgba(66,66,66)"
+    height="100px"
+    class="d-flex align-center mb-6 rank"
+    :href="`https://github.com/${user.githubId}`"
+    target="_blank"
+  >
+    <v-list-item>
+      <v-list-item-avatar
+        size="62"
+        class="badge"
+        :class="setBadgeColor(user.rank)"
+      >
+        {{ user.rank }}위
+      </v-list-item-avatar>
+      <v-list-item-content style="font-size: 1.3rem">
+        <div class="github-id">
+          {{ user.githubId }}
+        </div>
+        <div style="margin-top: 3px">
+          <span>{{ user.degree }}기 </span>
+          <span>{{ user.nickname }}</span>
+        </div>
+      </v-list-item-content>
+      <span>{{ numberWithCommas(user.point) }} Point</span>
+    </v-list-item>
+  </v-card>
 </template>
 
 <script>
-    import axios from "axios";
+import axios from "axios";
 
-    export default {
-        name: "MyCommitRank",
-        data() {
-            return {
-                user: {
-                    rank: "",
-                    degree: "",
-                    nickname: "",
-                    githubId: "",
-                    point: "",
-                },
-                badgeColor: {
-                    1: "gold",
-                    2: "silver",
-                    3: "bronze",
-                }
-            }
-        },
-        methods: {
-            setBadgeColor(rank) {
-                let badgeColor = this.badgeColor[rank];
-                return badgeColor ? badgeColor : "default";
-            },
-            numberWithCommas(point) {
-                return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
-            }
-        },
-        created() {
-            axios
-                .get(`${this.$store.state.requestUrl}/api/github/commit/rank/me`, {
-                    withCredentials: true
-                })
-                .then(res => {
-                    if (res.status === 200) {
-                        this.user = res.data
-                    }
-                });
-        }
+export default {
+  name: "MyCommitRank",
+  data() {
+    return {
+      user: {
+        rank: "",
+        degree: "",
+        nickname: "",
+        githubId: "",
+        point: ""
+      },
+      badgeColor: {
+        1: "gold",
+        2: "silver",
+        3: "bronze"
+      }
+    };
+  },
+  methods: {
+    setBadgeColor(rank) {
+      let badgeColor = this.badgeColor[rank];
+      return badgeColor ? badgeColor : "default";
+    },
+    numberWithCommas(point) {
+      return point.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
     }
+  },
+  created() {
+    axios
+      .get(`${this.$store.state.requestUrl}/api/github/commit/rank/me`, {
+        withCredentials: true
+      })
+      .then(res => {
+        if (res.status === 200) {
+          this.user = res.data;
+        }
+      });
+  }
+};
 </script>
 
 <style scoped>
-    .rank {
-        font-weight: bold;
-        transition: 0.3s;
-    }
-
-    .rank:hover {
-        box-shadow: 1px 3px 7px 4px rgba(0, 0, 0, 0.2);
-        background-color: rgba(66, 66, 66, 0.9) !important;
-    }
-
-    .badge {
-        color: #424242;
-        box-shadow: 1px 1px 4px gray inset;
-    }
-
-    .github-id {
-        font-weight: normal;
-        font-size: 0.8rem;
-    }
-
-    .default {
-        background: rgb(250, 250, 250);
-    }
+.rank {
+  font-weight: bold;
+  transition: 0.3s;
+}
+.rank:hover {
+  box-shadow: 1px 3px 7px 4px rgba(0, 0, 0, 0.2);
+  background-color: rgba(66, 66, 66, 0.9) !important;
+}
+.badge {
+  color: #424242;
+  box-shadow: 1px 1px 4px gray inset;
+}
+.github-id {
+  font-weight: normal;
+  font-size: 0.8rem;
+}
+.default {
+  background: rgb(250, 250, 250);
+}
 </style>

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -20,7 +20,7 @@ public class GithubCommit {
     private GithubCommit() {
     }
 
-    public GithubCommit(User user, LocalDate date, Integer point) {
+    public GithubCommit(User user, LocalDate date, int point) {
         validateDate(date);
         this.user = user;
         this.date = date;

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -4,6 +4,7 @@ import woowacrew.user.domain.User;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Entity
 public class GithubCommit {
@@ -27,5 +28,36 @@ public class GithubCommit {
         if (date.getDayOfMonth() != 1) {
             throw new RuntimeException();
         }
+    }
+
+    public boolean isSameUser(User user) {
+        return this.user.isSameUser(user);
+    }
+
+    public int getPoint() {
+        return point;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GithubCommit that = (GithubCommit) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "GithubCommit{" +
+                "id=" + id +
+                ", user=" + user +
+                ", date=" + date +
+                ", point=" + point +
+                '}';
     }
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 @Entity
 public class GithubCommit {
 
+    private static final int FIRST_DAY = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,7 +30,7 @@ public class GithubCommit {
     }
 
     private void validateDate(LocalDate date) {
-        if (date.getDayOfMonth() != 1) {
+        if (date.getDayOfMonth() != FIRST_DAY) {
             throw new RuntimeException();
         }
     }

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommit.java
@@ -17,6 +17,9 @@ public class GithubCommit {
     private LocalDate date;
     private Integer point;
 
+    private GithubCommit() {
+    }
+
     public GithubCommit(User user, LocalDate date, Integer point) {
         validateDate(date);
         this.user = user;

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
@@ -2,11 +2,15 @@ package woowacrew.github.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import woowacrew.user.domain.User;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface GithubCommitRepository extends JpaRepository<GithubCommit, Long> {
+
     List<GithubCommit> findByDateOrderByPointDesc(LocalDate date);
+
+    boolean existsByUserAndDate(User user, LocalDate date);
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
@@ -3,9 +3,10 @@ package woowacrew.github.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface GithubCommitRepository extends JpaRepository<GithubCommit, Long> {
-    List<GithubCommit> findByOrderByPointDesc();
+    List<GithubCommit> findByDateOrderByPointDesc(LocalDate date);
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/domain/GithubCommitRepository.java
@@ -3,6 +3,9 @@ package woowacrew.github.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GithubCommitRepository extends JpaRepository<GithubCommit, Long> {
+    List<GithubCommit> findByOrderByPointDesc();
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankAndPointDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankAndPointDto.java
@@ -1,0 +1,20 @@
+package woowacrew.github.dto;
+
+public class UserCommitRankAndPointDto {
+
+    private int rank;
+    private int point;
+
+    public UserCommitRankAndPointDto(int rank, int point) {
+        this.rank = rank;
+        this.point = point;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public int getPoint() {
+        return point;
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankDetailResponseDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankDetailResponseDto.java
@@ -3,34 +3,32 @@ package woowacrew.github.dto;
 public class UserCommitRankDetailResponseDto {
 
     private int rank;
-    private int degree;
     private int point;
+    private int degree;
     private String githubId;
     private String nickname;
 
     private UserCommitRankDetailResponseDto() {
     }
 
-    public static UserCommitRankDetailResponseDto of(UserCommitRankAndPointDto userCommitRankAndPointDto, int degree, String githubId, String nickname) {
-        UserCommitRankDetailResponseDto result = new UserCommitRankDetailResponseDto();
-        result.rank = userCommitRankAndPointDto.getRank();
-        result.degree = degree;
-        result.point = userCommitRankAndPointDto.getPoint();
-        result.githubId = githubId;
-        result.nickname = nickname;
-        return result;
+    public UserCommitRankDetailResponseDto(int rank, int point, int degree, String githubId, String nickname) {
+        this.rank = rank;
+        this.point = point;
+        this.degree = degree;
+        this.githubId = githubId;
+        this.nickname = nickname;
     }
 
     public int getRank() {
         return rank;
     }
 
-    public int getDegree() {
-        return degree;
-    }
-
     public int getPoint() {
         return point;
+    }
+
+    public int getDegree() {
+        return degree;
     }
 
     public String getGithubId() {

--- a/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankDetailResponseDto.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/dto/UserCommitRankDetailResponseDto.java
@@ -1,0 +1,43 @@
+package woowacrew.github.dto;
+
+public class UserCommitRankDetailResponseDto {
+
+    private int rank;
+    private int degree;
+    private int point;
+    private String githubId;
+    private String nickname;
+
+    private UserCommitRankDetailResponseDto() {
+    }
+
+    public static UserCommitRankDetailResponseDto of(UserCommitRankAndPointDto userCommitRankAndPointDto, int degree, String githubId, String nickname) {
+        UserCommitRankDetailResponseDto result = new UserCommitRankDetailResponseDto();
+        result.rank = userCommitRankAndPointDto.getRank();
+        result.degree = degree;
+        result.point = userCommitRankAndPointDto.getPoint();
+        result.githubId = githubId;
+        result.nickname = nickname;
+        return result;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public int getDegree() {
+        return degree;
+    }
+
+    public int getPoint() {
+        return point;
+    }
+
+    public String getGithubId() {
+        return githubId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/exception/NotFoundCommitRankException.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/exception/NotFoundCommitRankException.java
@@ -1,0 +1,7 @@
+package woowacrew.github.exception;
+
+public class NotFoundCommitRankException extends RuntimeException {
+    public NotFoundCommitRankException() {
+        super("해당 유저의 커밋 순위를 찾을 수 없습니다.");
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/exception/SaveGithubCommitFailException.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/exception/SaveGithubCommitFailException.java
@@ -1,0 +1,7 @@
+package woowacrew.github.exception;
+
+public class SaveGithubCommitFailException extends RuntimeException {
+    public SaveGithubCommitFailException() {
+        super("깃헙 커밋 정보를 저장하는데 실패하였습니다.");
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitCrawlingService.java
@@ -21,7 +21,11 @@ import java.util.stream.Collectors;
 public class GithubCommitCrawlingService {
 
     private static final Logger log = LoggerFactory.getLogger(GithubCommitCrawlingService.class);
+    private static final int FIRST_INDEX = 0;
     private static final String GITHUB_DOMAIN = "https://github.com/";
+    private static final String G_TAG = "g";
+    private static final String DAY_CLASS = "day";
+    private static final String DATE = "data-date";
 
     public List<GithubCommitStateDto> fetchCommitState(String githubId, LocalDate date) {
         try {
@@ -37,14 +41,13 @@ public class GithubCommitCrawlingService {
     private Elements fetchFullCommitState(String githubId) throws IOException {
         String url = GITHUB_DOMAIN + githubId;
         Document document = Jsoup.connect(url).get();
-        return document.getElementsByTag("g").get(0).getElementsByClass("day");
+        return document.getElementsByTag(G_TAG).get(FIRST_INDEX).getElementsByClass(DAY_CLASS);
     }
 
     private void checkContainsDate(Elements fullCommitState, LocalDate date) {
-        int firstIndex = 0;
         int lastIndex = fullCommitState.size() - 1;
 
-        LocalDate startDate = getDate(fullCommitState, firstIndex);
+        LocalDate startDate = getDate(fullCommitState, FIRST_INDEX);
         LocalDate endDate = getDate(fullCommitState, lastIndex);
         if (!isContainsDate(date, startDate, endDate)) {
             throw new DateRangeException();
@@ -52,7 +55,7 @@ public class GithubCommitCrawlingService {
     }
 
     private LocalDate getDate(Elements fullCommitState, int index) {
-        return LocalDate.parse(fullCommitState.get(index).attr("data-date"));
+        return LocalDate.parse(fullCommitState.get(index).attr(DATE));
     }
 
     private boolean isContainsDate(LocalDate date, LocalDate startDate, LocalDate endDate) {

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
@@ -6,6 +6,7 @@ import woowacrew.github.domain.GithubCommit;
 import woowacrew.github.domain.GithubCommitRepository;
 import woowacrew.github.dto.GithubCommitStateDto;
 import woowacrew.github.dto.UserCommitRankAndPointDto;
+import woowacrew.github.exception.NotFoundCommitRankException;
 import woowacrew.github.utils.GithubCommitCalculator;
 import woowacrew.user.domain.User;
 
@@ -46,8 +47,8 @@ public class GithubCommitInternalService {
                     rank.set(rank.get() + 1);
                     return githubCommit.isSameUser(user);
                 })
-                .findAny()
+                .findFirst()
                 .map(githubCommit -> new UserCommitRankAndPointDto(rank.get(), githubCommit.getPoint()))
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(NotFoundCommitRankException::new);
     }
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
@@ -67,7 +67,7 @@ public class GithubCommitInternalService {
         return this.githubCommitRepository.findByDateOrderByPointDesc(date)
                 .stream()
                 .filter(githubCommit -> {
-                    rank.set(rank.get() + 1);
+                    rank.getAndIncrement();
                     return githubCommit.isSameUser(user);
                 })
                 .findFirst()

--- a/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/service/GithubCommitInternalService.java
@@ -7,6 +7,7 @@ import woowacrew.github.domain.GithubCommitRepository;
 import woowacrew.github.dto.GithubCommitStateDto;
 import woowacrew.github.dto.UserCommitRankAndPointDto;
 import woowacrew.github.exception.NotFoundCommitRankException;
+import woowacrew.github.utils.DateConverter;
 import woowacrew.github.utils.GithubCommitCalculator;
 import woowacrew.user.domain.User;
 
@@ -41,7 +42,8 @@ public class GithubCommitInternalService {
     @Transactional(readOnly = true)
     public UserCommitRankAndPointDto getCommitRankByUser(User user) {
         AtomicInteger rank = new AtomicInteger();
-        return this.githubCommitRepository.findByOrderByPointDesc()
+        LocalDate date = DateConverter.toFirstDay(LocalDate.now());
+        return this.githubCommitRepository.findByDateOrderByPointDesc(date)
                 .stream()
                 .filter(githubCommit -> {
                     rank.set(rank.get() + 1);

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/DateConverter.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/DateConverter.java
@@ -1,0 +1,13 @@
+package woowacrew.github.utils;
+
+import java.time.LocalDate;
+
+public class DateConverter {
+
+    private DateConverter() {
+    }
+
+    public static LocalDate toFirstDay(LocalDate date) {
+        return LocalDate.of(date.getYear(), date.getMonthValue(), 1);
+    }
+}

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/DateConverter.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/DateConverter.java
@@ -4,10 +4,12 @@ import java.time.LocalDate;
 
 public class DateConverter {
 
+    private static final int FIRST_DAY = 1;
+
     private DateConverter() {
     }
 
     public static LocalDate toFirstDay(LocalDate date) {
-        return LocalDate.of(date.getYear(), date.getMonthValue(), 1);
+        return LocalDate.of(date.getYear(), date.getMonthValue(), FIRST_DAY);
     }
 }

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitCalculator.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitCalculator.java
@@ -15,6 +15,8 @@ public class GithubCommitCalculator {
 
     private static final int MIN_BONUS_POINT = 0;
     private static final int MAX_BONUS_POINT = 3;
+    private static final int DEFAULT_BASE = 2;
+    private static final int DEFAULT_MULTIPLIER = 10;
 
     private GithubCommitCalculator() {
     }
@@ -31,8 +33,8 @@ public class GithubCommitCalculator {
     }
 
     private static int calculate(int commitCount, int bonusPoint) {
-        bonusPoint = (int) Math.pow(2, bonusPoint);
-        return (commitCount * 10) * bonusPoint;
+        bonusPoint = (int) Math.pow(DEFAULT_BASE, bonusPoint);
+        return (commitCount * DEFAULT_MULTIPLIER) * bonusPoint;
     }
 
     private static int getBonusPoint(int commitCount, int bonusPoint) {

--- a/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitStateConverter.java
+++ b/woowacrew-domain/src/main/java/woowacrew/github/utils/GithubCommitStateConverter.java
@@ -7,12 +7,15 @@ import java.time.LocalDate;
 
 public class GithubCommitStateConverter {
 
+    private static final String DATE = "data-date";
+    private static final String COMMIT_COUNT = "data-count";
+
     private GithubCommitStateConverter() {
     }
 
     public static GithubCommitStateDto toDto(Element element) {
-        LocalDate date = LocalDate.parse(element.attr("data-date"));
-        int commitCount = Integer.parseInt(element.attr("data-count"));
+        LocalDate date = LocalDate.parse(element.attr(DATE));
+        int commitCount = Integer.parseInt(element.attr(COMMIT_COUNT));
         return new GithubCommitStateDto(date, commitCount);
     }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
@@ -41,5 +41,23 @@ class GithubCommitRepositoryTest {
             assertNotNull(githubCommit);
         }
         assertThat(result.size()).isEqualTo(users.size());
+    }
+
+    @Test
+    void 유저와_날짜를_받아서_존재하는_정보가_없는_경우() {
+        userRepository.findById(1L).ifPresent(user -> {
+            boolean result = githubCommitRepository.existsByUserAndDate(user, LocalDate.of(1990, 5, 1));
+            assertFalse(result);
+        });
+    }
+
+    @Test
+    void 유저와_날짜를_받아서_존재하는_정보가_있는_경우() {
+        userRepository.findById(1L).ifPresent(user -> {
+            LocalDate date = LocalDate.of(2020, 6, 1);
+            githubCommitRepository.save(new GithubCommit(user, date, 100));
+            boolean result = githubCommitRepository.existsByUserAndDate(user, date);
+            assertTrue(result);
+        });
     }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
@@ -30,14 +30,15 @@ class GithubCommitRepositoryTest {
     @Test
     void 정상적으로_1위부터_50위까지_커밋_랭킹을_가져온다() {
         List<User> users = userRepository.findAll();
+        LocalDate date = LocalDate.of(2020, 6, 1);
+
         for (int i = 0; i < users.size(); i++) {
-            githubCommitRepository.save(new GithubCommit(users.get(i), LocalDate.of(2020, 6, 1), i * 100));
+            githubCommitRepository.save(new GithubCommit(users.get(i), date, i * 100));
         }
 
-        List<GithubCommit> result = githubCommitRepository.findByOrderByPointDesc();
+        List<GithubCommit> result = githubCommitRepository.findByDateOrderByPointDesc(date);
         for (GithubCommit githubCommit : result) {
             assertNotNull(githubCommit);
-            System.out.println(githubCommit.getPoint());
         }
         assertThat(result.size()).isEqualTo(users.size());
     }

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitRepositoryTest.java
@@ -1,0 +1,44 @@
+package woowacrew.github.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import woowacrew.JpaTestConfiguration;
+import woowacrew.user.domain.User;
+import woowacrew.user.domain.UserRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@ContextConfiguration(classes = JpaTestConfiguration.class)
+class GithubCommitRepositoryTest {
+
+    @Autowired
+    private GithubCommitRepository githubCommitRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void 정상적으로_1위부터_50위까지_커밋_랭킹을_가져온다() {
+        List<User> users = userRepository.findAll();
+        for (int i = 0; i < users.size(); i++) {
+            githubCommitRepository.save(new GithubCommit(users.get(i), LocalDate.of(2020, 6, 1), i * 100));
+        }
+
+        List<GithubCommit> result = githubCommitRepository.findByOrderByPointDesc();
+        for (GithubCommit githubCommit : result) {
+            assertNotNull(githubCommit);
+            System.out.println(githubCommit.getPoint());
+        }
+        assertThat(result.size()).isEqualTo(users.size());
+    }
+}

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
@@ -5,9 +5,10 @@ import woowacrew.user.domain.User;
 
 import java.time.LocalDate;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GithubCommitTest {
 
@@ -27,5 +28,15 @@ class GithubCommitTest {
             LocalDate date = LocalDate.of(2020, 6, 2);
             new GithubCommit(mockUser, date, 300);
         });
+    }
+
+    @Test
+    void 같은_유저인지_확인한다() {
+        User mockUser = mock(User.class);
+        GithubCommit githubCommit = new GithubCommit(mockUser, LocalDate.of(2020, 6, 1), 300);
+
+        when(mockUser.isSameUser(any())).thenReturn(true);
+
+        assertTrue(githubCommit.isSameUser(mockUser));
     }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/domain/GithubCommitTest.java
@@ -35,7 +35,7 @@ class GithubCommitTest {
         User mockUser = mock(User.class);
         GithubCommit githubCommit = new GithubCommit(mockUser, LocalDate.of(2020, 6, 1), 300);
 
-        when(mockUser.isSameUser(any())).thenReturn(true);
+        when(mockUser.isSameUser(any(User.class))).thenReturn(true);
 
         assertTrue(githubCommit.isSameUser(mockUser));
     }

--- a/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
@@ -10,6 +10,7 @@ import woowacrew.github.domain.GithubCommitRepository;
 import woowacrew.github.dto.GithubCommitStateDto;
 import woowacrew.github.dto.UserCommitRankAndPointDto;
 import woowacrew.github.exception.GithubCommitCrawlingFailException;
+import woowacrew.github.exception.NotFoundCommitRankException;
 import woowacrew.user.domain.User;
 
 import java.time.LocalDate;
@@ -116,6 +117,6 @@ class GithubCommitInternalServiceTest {
 
         when(githubCommitRepository.findByOrderByPointDesc()).thenReturn(new ArrayList<>());
 
-        assertThrows(RuntimeException.class, () -> githubCommitInternalService.getCommitRankByUser(mockUser));
+        assertThrows(NotFoundCommitRankException.class, () -> githubCommitInternalService.getCommitRankByUser(mockUser));
     }
 }

--- a/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
@@ -1,5 +1,6 @@
 package woowacrew.github.service;
 
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -65,11 +66,11 @@ class GithubCommitInternalServiceTest {
         List<User> users = getMockUsers(mockUser, 4);
 
         when(mockUser.getGithubId()).thenReturn("githubId");
-        when(githubCommitCrawlingService.fetchCommitState(anyString(), any())).thenReturn(commitState);
+        when(githubCommitCrawlingService.fetchCommitState(anyString(), any(LocalDate.class))).thenReturn(commitState);
 
         githubCommitInternalService.save(users, date);
 
-        verify(githubCommitRepository, times(users.size())).save(any());
+        verify(githubCommitRepository, times(users.size())).save(any(GithubCommit.class));
     }
 
     private List<User> getMockUsers(User mockUser, int repetitionCount) {
@@ -87,13 +88,13 @@ class GithubCommitInternalServiceTest {
         LocalDate date = LocalDate.of(2020, 6, 1);
 
         when(mockUser.getGithubId()).thenReturn("githubId");
-        when(githubCommitCrawlingService.fetchCommitState(anyString(), any()))
+        when(githubCommitCrawlingService.fetchCommitState(anyString(), any(LocalDate.class)))
                 .thenThrow(GithubCommitCrawlingFailException.class);
 
         assertThrows(SaveGithubCommitFailException.class, () -> githubCommitInternalService.save(users, date));
 
-        verify(githubCommitRepository, times(0)).save(any());
-        verify(githubCommitCrawlingService, times(1)).fetchCommitState(anyString(), any());
+        verify(githubCommitRepository, times(0)).save(any(GithubCommit.class));
+        verify(githubCommitCrawlingService, times(1)).fetchCommitState(anyString(), any(LocalDate.class));
     }
 
     @Test
@@ -101,8 +102,8 @@ class GithubCommitInternalServiceTest {
         User mockUser = mock(User.class);
         GithubCommit mockGithubCommit = mock(GithubCommit.class);
 
-        when(githubCommitRepository.findByDateOrderByPointDesc(any())).thenReturn(Collections.singletonList(mockGithubCommit));
-        when(mockGithubCommit.isSameUser(any())).thenReturn(true);
+        when(githubCommitRepository.findByDateOrderByPointDesc(any(LocalDate.class))).thenReturn(Collections.singletonList(mockGithubCommit));
+        when(mockGithubCommit.isSameUser(any(User.class))).thenReturn(true);
         when(mockGithubCommit.getPoint()).thenReturn(200);
 
         UserCommitRankAndPointDto result = githubCommitInternalService.getCommitRankByUser(mockUser);
@@ -116,7 +117,7 @@ class GithubCommitInternalServiceTest {
     void 커밋_정보를_못찾는_경우_예외가_발생한다() {
         User mockUser = mock(User.class);
 
-        when(githubCommitRepository.findByDateOrderByPointDesc(any())).thenReturn(new ArrayList<>());
+        when(githubCommitRepository.findByDateOrderByPointDesc(any(LocalDate.class))).thenReturn(Lists.emptyList());
 
         assertThrows(NotFoundCommitRankException.class, () -> githubCommitInternalService.getCommitRankByUser(mockUser));
     }

--- a/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
@@ -11,6 +11,7 @@ import woowacrew.github.dto.GithubCommitStateDto;
 import woowacrew.github.dto.UserCommitRankAndPointDto;
 import woowacrew.github.exception.GithubCommitCrawlingFailException;
 import woowacrew.github.exception.NotFoundCommitRankException;
+import woowacrew.github.exception.SaveGithubCommitFailException;
 import woowacrew.user.domain.User;
 
 import java.time.LocalDate;
@@ -89,7 +90,7 @@ class GithubCommitInternalServiceTest {
         when(githubCommitCrawlingService.fetchCommitState(anyString(), any()))
                 .thenThrow(GithubCommitCrawlingFailException.class);
 
-        assertThrows(GithubCommitCrawlingFailException.class, () -> githubCommitInternalService.save(users, date));
+        assertThrows(SaveGithubCommitFailException.class, () -> githubCommitInternalService.save(users, date));
 
         verify(githubCommitRepository, times(0)).save(any());
         verify(githubCommitCrawlingService, times(1)).fetchCommitState(anyString(), any());

--- a/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
+++ b/woowacrew-domain/src/test/java/woowacrew/github/service/GithubCommitInternalServiceTest.java
@@ -100,7 +100,7 @@ class GithubCommitInternalServiceTest {
         User mockUser = mock(User.class);
         GithubCommit mockGithubCommit = mock(GithubCommit.class);
 
-        when(githubCommitRepository.findByOrderByPointDesc()).thenReturn(Collections.singletonList(mockGithubCommit));
+        when(githubCommitRepository.findByDateOrderByPointDesc(any())).thenReturn(Collections.singletonList(mockGithubCommit));
         when(mockGithubCommit.isSameUser(any())).thenReturn(true);
         when(mockGithubCommit.getPoint()).thenReturn(200);
 
@@ -115,7 +115,7 @@ class GithubCommitInternalServiceTest {
     void 커밋_정보를_못찾는_경우_예외가_발생한다() {
         User mockUser = mock(User.class);
 
-        when(githubCommitRepository.findByOrderByPointDesc()).thenReturn(new ArrayList<>());
+        when(githubCommitRepository.findByDateOrderByPointDesc(any())).thenReturn(new ArrayList<>());
 
         assertThrows(NotFoundCommitRankException.class, () -> githubCommitInternalService.getCommitRankByUser(mockUser));
     }

--- a/woowacrew-web/build.gradle
+++ b/woowacrew-web/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.rometools:rome:1.12.0'
     implementation 'com.ullink.slack:simpleslackapi:1.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
-    compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
+    implementation 'com.github.ben-manes.caffeine:caffeine:2.5.6'
 
     runtimeOnly 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/woowacrew-web/src/main/java/woowacrew/github/controller/CommitRankApiController.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/controller/CommitRankApiController.java
@@ -20,7 +20,7 @@ public class CommitRankApiController {
 
     @GetMapping("/me")
     public ResponseEntity<UserCommitRankDetailResponseDto> getMyCommitRank(UserContext userContext) {
-        UserCommitRankDetailResponseDto result = githubCommitService.getMyCommitRank(userContext);
+        UserCommitRankDetailResponseDto result = githubCommitService.getLoginUserCommitRank(userContext);
         return ResponseEntity.ok(result);
     }
 }

--- a/woowacrew-web/src/main/java/woowacrew/github/controller/CommitRankApiController.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/controller/CommitRankApiController.java
@@ -1,0 +1,26 @@
+package woowacrew.github.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woowacrew.github.dto.UserCommitRankDetailResponseDto;
+import woowacrew.github.service.GithubCommitService;
+import woowacrew.user.dto.UserContext;
+
+@RestController
+@RequestMapping("/api/github/commit/rank")
+public class CommitRankApiController {
+
+    private GithubCommitService githubCommitService;
+
+    public CommitRankApiController(GithubCommitService githubCommitService) {
+        this.githubCommitService = githubCommitService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserCommitRankDetailResponseDto> getMyCommitRank(UserContext userContext) {
+        UserCommitRankDetailResponseDto result = githubCommitService.getMyCommitRank(userContext);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
@@ -36,6 +36,8 @@ public class GithubCommitService {
         User user = userInternalService.findById(userContext.getId());
         int degree = user.getDegree().getDegreeNumber();
         UserCommitRankAndPointDto userCommitRankAndPointDto = githubCommitInternalService.getCommitRankByUser(user);
-        return UserCommitRankDetailResponseDto.of(userCommitRankAndPointDto, degree, user.getGithubId(), user.getNickname());
+        int rank = userCommitRankAndPointDto.getRank();
+        int point = userCommitRankAndPointDto.getPoint();
+        return new UserCommitRankDetailResponseDto(rank, point, degree, user.getGithubId(), user.getNickname());
     }
 }

--- a/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
@@ -2,7 +2,10 @@ package woowacrew.github.service;
 
 import org.springframework.stereotype.Service;
 import woowacrew.github.dto.GithubCommitRequestDto;
+import woowacrew.github.dto.UserCommitRankAndPointDto;
+import woowacrew.github.dto.UserCommitRankDetailResponseDto;
 import woowacrew.user.domain.User;
+import woowacrew.user.dto.UserContext;
 import woowacrew.user.service.UserInternalService;
 
 import java.time.LocalDate;
@@ -27,5 +30,12 @@ public class GithubCommitService {
 
     private LocalDate createDate(GithubCommitRequestDto requestDto) {
         return LocalDate.of(requestDto.getYear(), requestDto.getMonth(), 1);
+    }
+
+    public UserCommitRankDetailResponseDto getMyCommitRank(UserContext userContext) {
+        User user = userInternalService.findById(userContext.getId());
+        int degree = user.getDegree().getDegreeNumber();
+        UserCommitRankAndPointDto userCommitRankAndPointDto = githubCommitInternalService.getCommitRankByUser(user);
+        return UserCommitRankDetailResponseDto.of(userCommitRankAndPointDto, degree, user.getGithubId(), user.getNickname());
     }
 }

--- a/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
+++ b/woowacrew-web/src/main/java/woowacrew/github/service/GithubCommitService.java
@@ -32,7 +32,7 @@ public class GithubCommitService {
         return LocalDate.of(requestDto.getYear(), requestDto.getMonth(), 1);
     }
 
-    public UserCommitRankDetailResponseDto getMyCommitRank(UserContext userContext) {
+    public UserCommitRankDetailResponseDto getLoginUserCommitRank(UserContext userContext) {
         User user = userInternalService.findById(userContext.getId());
         int degree = user.getDegree().getDegreeNumber();
         UserCommitRankAndPointDto userCommitRankAndPointDto = githubCommitInternalService.getCommitRankByUser(user);

--- a/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
-import woowacrew.github.dto.UserCommitRankAndPointDto;
 import woowacrew.github.dto.UserCommitRankDetailResponseDto;
 import woowacrew.github.service.GithubCommitService;
 import woowacrew.security.SecurityContextSupport;
@@ -43,9 +42,7 @@ class CommitRankApiControllerTest {
 
     @Test
     void 정상적으로_로그인중인_유저의_커밋_랭킹_정보를_가져온다() throws Exception {
-        UserCommitRankAndPointDto userCommitRankAndPointDto = new UserCommitRankAndPointDto(1, 300);
-        UserCommitRankDetailResponseDto userCommitRankDetailResponseDto = UserCommitRankDetailResponseDto.of(userCommitRankAndPointDto, 1, "hyo", "hyoo");
-
+        UserCommitRankDetailResponseDto userCommitRankDetailResponseDto = new UserCommitRankDetailResponseDto(1, 300, 1, "hyo", "hyoo");
         when(githubCommitService.getMyCommitRank(userContext)).thenReturn(userCommitRankDetailResponseDto);
 
         mockMvc.perform(get("/api/github/commit/rank/me"))

--- a/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
@@ -43,7 +43,7 @@ class CommitRankApiControllerTest {
     @Test
     void 정상적으로_로그인중인_유저의_커밋_랭킹_정보를_가져온다() throws Exception {
         UserCommitRankDetailResponseDto userCommitRankDetailResponseDto = new UserCommitRankDetailResponseDto(1, 300, 1, "hyo", "hyoo");
-        when(githubCommitService.getMyCommitRank(userContext)).thenReturn(userCommitRankDetailResponseDto);
+        when(githubCommitService.getLoginUserCommitRank(userContext)).thenReturn(userCommitRankDetailResponseDto);
 
         mockMvc.perform(get("/api/github/commit/rank/me"))
                 .andExpect(status().isOk());

--- a/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/controller/CommitRankApiControllerTest.java
@@ -1,0 +1,54 @@
+package woowacrew.github.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import woowacrew.github.dto.UserCommitRankAndPointDto;
+import woowacrew.github.dto.UserCommitRankDetailResponseDto;
+import woowacrew.github.service.GithubCommitService;
+import woowacrew.security.SecurityContextSupport;
+import woowacrew.user.domain.UserRole;
+import woowacrew.user.dto.UserContext;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CommitRankApiController.class,
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = "woowacrew.security.*")})
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+class CommitRankApiControllerTest {
+
+    @MockBean
+    private GithubCommitService githubCommitService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private UserContext userContext;
+
+    @BeforeEach
+    void setUp() {
+        userContext = new UserContext(1L, "12345", "admin", UserRole.ROLE_PRECOURSE);
+        SecurityContextSupport.updateContext(userContext);
+    }
+
+    @Test
+    void 정상적으로_로그인중인_유저의_커밋_랭킹_정보를_가져온다() throws Exception {
+        UserCommitRankAndPointDto userCommitRankAndPointDto = new UserCommitRankAndPointDto(1, 300);
+        UserCommitRankDetailResponseDto userCommitRankDetailResponseDto = UserCommitRankDetailResponseDto.of(userCommitRankAndPointDto, 1, "hyo", "hyoo");
+
+        when(githubCommitService.getMyCommitRank(userContext)).thenReturn(userCommitRankDetailResponseDto);
+
+        mockMvc.perform(get("/api/github/commit/rank/me"))
+                .andExpect(status().isOk());
+    }
+}

--- a/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
@@ -51,7 +51,7 @@ class GithubCommitServiceTest {
         when(userInternalService.findById(anyLong())).thenReturn(user);
         when(githubCommitInternalService.getCommitRankByUser(user)).thenReturn(new UserCommitRankAndPointDto(1, 200));
 
-        UserCommitRankDetailResponseDto result = githubCommitService.getMyCommitRank(userContext);
+        UserCommitRankDetailResponseDto result = githubCommitService.getLoginUserCommitRank(userContext);
 
         assertNotNull(result);
         assertThat(result.getRank()).isEqualTo(1);

--- a/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
@@ -5,12 +5,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import woowacrew.degree.domain.Degree;
 import woowacrew.github.dto.GithubCommitRequestDto;
+import woowacrew.github.dto.UserCommitRankAndPointDto;
+import woowacrew.github.dto.UserCommitRankDetailResponseDto;
+import woowacrew.user.domain.User;
+import woowacrew.user.domain.UserRole;
+import woowacrew.user.dto.UserContext;
 import woowacrew.user.service.UserInternalService;
 
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class GithubCommitServiceTest {
@@ -30,5 +39,25 @@ class GithubCommitServiceTest {
 
         verify(userInternalService, times(1)).findByGithubIdIsNotNull();
         verify(githubCommitInternalService, times(1)).save(any(), any());
+    }
+
+    @Test
+    void 정상적으로_나의_커밋_랭킹_정보를_가져온다() {
+        User user = new User("oauthId", "githubId", new Degree());
+        user.updateUserInfo("hyo", LocalDate.of(1995, 6, 8));
+
+        UserContext userContext = new UserContext(1L, user.getOauthId(), user.getNickname(), UserRole.ROLE_PRECOURSE);
+
+        when(userInternalService.findById(any())).thenReturn(user);
+        when(githubCommitInternalService.getCommitRankByUser(user)).thenReturn(new UserCommitRankAndPointDto(1, 200));
+
+        UserCommitRankDetailResponseDto result = githubCommitService.getMyCommitRank(userContext);
+
+        assertNotNull(result);
+        assertThat(result.getRank()).isEqualTo(1);
+        assertThat(result.getDegree()).isEqualTo(0);
+        assertThat(result.getPoint()).isEqualTo(200);
+        assertThat(result.getGithubId()).isEqualTo("githubId");
+        assertThat(result.getNickname()).isEqualTo("hyo");
     }
 }

--- a/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
+++ b/woowacrew-web/src/test/java/woowacrew/github/service/GithubCommitServiceTest.java
@@ -38,7 +38,7 @@ class GithubCommitServiceTest {
         githubCommitService.save(new GithubCommitRequestDto(2020, 6));
 
         verify(userInternalService, times(1)).findByGithubIdIsNotNull();
-        verify(githubCommitInternalService, times(1)).save(any(), any());
+        verify(githubCommitInternalService, times(1)).save(anyList(), any(LocalDate.class));
     }
 
     @Test
@@ -48,7 +48,7 @@ class GithubCommitServiceTest {
 
         UserContext userContext = new UserContext(1L, user.getOauthId(), user.getNickname(), UserRole.ROLE_PRECOURSE);
 
-        when(userInternalService.findById(any())).thenReturn(user);
+        when(userInternalService.findById(anyLong())).thenReturn(user);
         when(githubCommitInternalService.getCommitRankByUser(user)).thenReturn(new UserCommitRankAndPointDto(1, 200));
 
         UserCommitRankDetailResponseDto result = githubCommitService.getMyCommitRank(userContext);


### PR DESCRIPTION
resolve #385, #386 
아직 모든 랭킹을 가져오는 API를 만들고 있어서 프론트는 일단 비활성화 했습니다.

1. 로그인을 하고, 크루라면
- 커밋 정보가 없으면 크롤링하여 저장합니다.
- 아래와 같이 현재 나의 랭킹을 조회할 수 있습니다.(까만색 칸)

![image](https://user-images.githubusercontent.com/41109150/88041776-d69e2a00-cb85-11ea-9762-ab06ea55fd00.png)

2. 로그인을 하지 않거나, PRECOURSE이면
- 나의 랭킹을 조회할 수 있는 칸이 없습니다.
- 전체 랭킹은 조회할 수 있습니다.
![image](https://user-images.githubusercontent.com/41109150/88041948-1bc25c00-cb86-11ea-9672-0954c600d1d0.png)